### PR TITLE
Add a "camera_extras" lua script and python example

### DIFF
--- a/python/packages/frame_msg/examples/camera_extras.py
+++ b/python/packages/frame_msg/examples/camera_extras.py
@@ -1,0 +1,59 @@
+import asyncio
+import traceback
+import sys
+from pathlib import Path
+from frame_msg import FrameMsg, RxPhoto, TxCaptureSettings
+
+async def main():
+    frame = FrameMsg()
+    try:
+        await frame.connect()
+
+        lua_script = '''
+        require('camera_extras')
+
+        -- Capture a frame with the enhancements of this library
+        capture()
+
+        -- Transfer the frame over Bluetooth as it is read
+        MTU = frame.bluetooth.max_length()
+        while true do
+            data = frame.camera.read(MTU // 2 - 1)
+            if data == nil then break end
+            print(tohex(data))
+        end
+
+        print('END')
+        sleep(0.3)
+        '''
+
+        # Send the library dependencies
+        await frame.upload_stdlua_libs(lib_names=['camera_extras'], minified=False)
+
+        # Send the main lua application from this project to Frame that will run the app
+        await frame.upload_file_from_string(lua_script, "frame_app.lua")
+
+        # attach the print response handler so we can see stdout from Frame Lua print() statements
+        frame.attach_print_response_handler()
+
+        # "require" the main frame_app lua file to run it, and block until it has started.
+        await frame.start_frame_app()
+
+	# Wait for 5 seconds that the script runs
+        await asyncio.sleep(30.0)
+
+        # unhook the print handler
+        frame.detach_print_response_handler()
+
+        # break out of the frame app loop and reboot Frame
+        await frame.stop_frame_app()
+
+    except Exception as e:
+        print(f"An error occurred: {e}")
+        traceback.print_exc()
+    finally:
+        # clean disconnection
+        await frame.disconnect()
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/python/packages/frame_msg/src/frame_msg/lua/camera_extras.lua
+++ b/python/packages/frame_msg/src/frame_msg/lua/camera_extras.lua
@@ -1,0 +1,113 @@
+-- Wait that the IMU becomes stable before taking an image capture.
+function wait_imu_stable(
+   -- The initial threshold for taking a picture
+   thres_accelerometer,
+   -- How much the threshold increases every attempt
+   thres_accelerometer_inc,
+   -- The initial threshold for taking a picture
+   thres_compass,
+   -- How much the threshold increases every attempt
+   thres_compass_inc
+)
+   -- Collect the initial values
+   prev = frame.imu.raw()
+
+   while true do
+
+      -- Give some time to the IMU
+      frame.sleep(0.05)
+
+      -- Take a measurement
+      this = frame.imu.raw()
+
+      -- Compute the difference in orientation
+      dx = this.compass.x - prev.compass.x
+      dy = this.compass.y - prev.compass.y
+      dz = this.compass.z - prev.compass.z
+      d_compass = dx * dx + dy * dy + dz * dz
+
+      -- Compute the difference in acceleration
+      dx = this.accelerometer.x - prev.accelerometer.x
+      dy = this.accelerometer.y - prev.accelerometer.y
+      dz = this.accelerometer.z - prev.accelerometer.z
+      d_accelerometer = dx * dx + dy * dy + dz * dz
+
+      --print("compass (d:"..d_compass..", t:"..thres_compass..", accelerometer (d:"..d_accelerometer..", t: "..thres_accelerometer..")")
+
+      -- Perform the comparison of both
+      if d_compass < thres_compass and d_accelerometer < thres_accelerometer then
+         break
+      end
+
+      -- Decrease exigence of the thresholds
+      thres_accelerometer = thres_accelerometer + thres_accelerometer_inc
+      thres_compass = thres_compass + thres_compass_inc
+
+      -- Persist the previous sample for comparison
+      prev = this
+   end
+end
+
+function set_pipeline()
+   -- Replace the default image pipeline
+   pipeline = {}
+   frame.camera.mpix.op.debayer_2x2(pipeline)
+   frame.camera.mpix.op.crop(pipeline, 128, 128, 256, 256)
+   frame.camera.mpix.op.correct_black_level(pipeline)
+   frame.camera.mpix.op.correct_white_balance(pipeline)
+   frame.camera.mpix.op.kernel_denoise_3x3(pipeline)
+   frame.camera.mpix.op.jpeg_encode(pipeline)
+   frame.camera.mpix.set_pipeline(pipeline)
+end
+
+function auto_black_level(stats)
+   sum = 0
+   for i = 1, #stats.y_histogram do
+      sum = sum + stats.y_histogram[i]
+      if sum > 10 then black_level = stats.y_histogram_vals[i] break end
+   end
+
+   -- Apply the controls
+   frame.camera.mpix.set_ctrl(frame.camera.mpix.cid.BLACK_LEVEL, black_level or 0)
+end
+
+function auto_white_balance(stats)
+   if stats.rgb_average_r == 0 then
+      red_balance_q10 = 1.0
+   else
+      red_balance_q10 = (stats.rgb_average_g << 10) // stats.rgb_average_r;
+   end
+
+   if stats.rgb_average_b == 0 then
+      blue_balance_q10 = 1.0
+   else
+     blue_balance_q10 = (stats.rgb_average_g << 10) // stats.rgb_average_b;
+   end
+
+   -- Apply the controls
+   frame.camera.mpix.set_ctrl(frame.camera.mpix.cid.RED_BALANCE, red_balance_q10)
+   frame.camera.mpix.set_ctrl(frame.camera.mpix.cid.BLUE_BALANCE, blue_balance_q10)
+end
+
+function capture()
+   set_pipeline()
+
+   frame.camera.power_save(false)
+   wait_imu_stable(100, 10, 100, 10)
+   frame.camera.capture{resolution=640}
+   while not frame.camera.image_ready() do
+      frame.sleep(0.005)
+   end
+
+   stats = frame.camera.mpix.get_stats()
+
+   auto_black_level(stats)
+   auto_white_balance(stats)
+end
+
+-- Helper to print the data as hexadecimal
+function tohex(data)
+    local hex = ""
+    for i = 1, #data do hex = hex .. string.format('%02x', data:byte(i)) end
+    return hex
+end


### PR DESCRIPTION
> Imported from https://github.com/brilliantlabsAR/brilliant_sdk_python/pull/1

Add a script to make use of a custom pipeline with automatic white balance and black level.

In addition to the input/output format conversions, the typical "3A" of camera control is then provided as follow

- Auto-White-Balance: there is a libmpix operation for it
- Auto-Exposure: the image sensor has auto-exposure enabled (enabled by Seeed Studio team, checked against the datasheet, tested and works well)
- Auto-Focus: given there is no focus motor, instead, the IMU is used to detect when the device is getting stable and take a photo there. The exigence of auto-focus is going down over time, to avoid waiting forever and still take a capture if things remain in movement.

Example usage:

```
python packages/frame_msg/examples/camera_extras.py | xxd -r -p >/tmp/halo_camera_libmpix.jpeg
```

It currently prints the image as hexdump, but I think there is a better API to transfer images as raw (no encoding == more compact). I was not able to get it to work with the `mk3` board I have.

Is this suitable integration? Anything I should change?
Thanks.