### PR TITLE
Halo reset duration and added guard for Remove signal

### DIFF
--- a/flutter/packages/frame_ble/lib/brilliant_device.dart
+++ b/flutter/packages/frame_ble/lib/brilliant_device.dart
@@ -138,7 +138,7 @@ class BrilliantDevice {
   Future<void> sendBreakSignal() async {
     _log.info("Sending break signal");
     await sendString("\x03", awaitResponse: false, log: false);
-    // short delay to allow the break to complete on Frame before sending Lua commands
+    // short delay to allow the break to complete on Frame/Halo before sending Lua commands
     await Future.delayed(const Duration(milliseconds: 200));
   }
 
@@ -146,19 +146,21 @@ class BrilliantDevice {
     _log.info("Sending reset signal");
     await sendString("\x04", awaitResponse: false, log: false);
     if (type == BrilliantDeviceType.halo) {
-      // Halo may take longer to reset
-      await Future.delayed(const Duration(milliseconds: 3000));
+      await Future.delayed(const Duration(milliseconds: 200));
     } else {
       // Frame takes ~200ms reset
       await Future.delayed(const Duration(milliseconds: 200));
     }
-    await Future.delayed(const Duration(milliseconds: 200));
   }
 
   Future<void> sendRemoveSignal() async {
-    _log.info("Sending remove signal");
-    await sendString("\x05", awaitResponse: false, log: false);
-    await Future.delayed(const Duration(milliseconds: 200));
+    if (type == BrilliantDeviceType.halo) {
+      _log.info("Sending remove signal");
+      await sendString("\x05", awaitResponse: false, log: false);
+    } else {
+      _log.info("Remove signal is Halo-only");
+    }
+      //await Future.delayed(const Duration(milliseconds: 200));
   }
 
   Future<String?> sendString(


### PR DESCRIPTION
Reset signal doesn't need a 3s wait from the client. If the main.lua is complex, then startup might take a while on either Frame or Halo, but this should be managed by application code blocking until a startup string has been received.

Remove signal (delete main.lua) is only available on Halo so this guard was added.