### PR TITLE
Full-duplex realtime_openai example (Python + Flutter) with AEC barge-in

### DIFF
--- a/flutter/packages/simple_brilliant_app/example/realtime_openai/README.md
+++ b/flutter/packages/simple_brilliant_app/example/realtime_openai/README.md
@@ -20,7 +20,7 @@ Halo speaker <--LC3(16k)-- phone <--downsample+encode-- PCM16 24kHz <-- endpoint
 
 The client (`lib/openai_realtime.dart`) speaks the current OpenAI Realtime **GA** interface: `session.type: realtime`, nested `audio.{input,output}` config (24kHz `audio/pcm`), and `response.output_audio.delta` events. OpenAI has disabled the older beta shape, and self-hosted OpenAI-Realtime-compatible stacks such as [huggingface/speech-to-speech](https://github.com/huggingface/speech-to-speech) also speak GA — so one shape covers both.
 
-Auth is header-based (`Authorization: Bearer …`, omitted when the key is blank), unlike Gemini's query-parameter key. Server-side VAD is enabled (`turn_detection: server_vad`), so the endpoint auto-commits the input buffer, auto-creates responses, and emits `input_audio_buffer.speech_started` on barge-in.
+Auth is header-based (`Authorization: Bearer …`, omitted when the key is blank), unlike Gemini's query-parameter key. Server-side VAD is enabled with `interrupt_response` (`turn_detection: {server_vad, interrupt_response}`), so the endpoint auto-commits the input buffer, auto-creates responses, and stops generating on a barge-in — emitting `input_audio_buffer.speech_started` when you start talking.
 
 ## Usage
 
@@ -31,7 +31,14 @@ Auth is header-based (`Authorization: Bearer …`, omitted when the key is blank
 
 ## Interruption and echo
 
-There is no acoustic echo cancellation yet, and the Halo mic can hear the Halo (bone conduction) speaker. By default the app is **half-duplex**: the mic is muted while response audio is playing. The *Allow barge-in* switch keeps the mic open during replies so the endpoint's server-side VAD can interrupt the response (`input_audio_buffer.speech_started` drops all queued audio) — expect the model to hear itself in this mode until AEC lands.
+The app is **full-duplex**: the mic streams continuously, even while a reply is playing, so you can talk over the assistant to interrupt it (barge-in). This relies on the Halo firmware's on-device **acoustic echo canceller** to strip the bone-conduction speaker's bleed out of the mic feed — otherwise the server VAD would hear the assistant's own voice and the reply would interrupt itself.
+
+On a barge-in (`input_audio_buffer.speech_started` while a reply is playing) the client cancels the server's reply (`response.cancel`), drops the reply's trailing audio deltas, and flushes the queued playback so the assistant stops promptly (the server can't unsend audio it already streamed to us).
+
+Two on-device switches (applied at mic start) mirror the Python sample's `--aec-off` / `--no-voice-mode`, both **on** by default:
+
+- **Echo cancellation (AEC)** — removes the speaker bleed so the mic can stay open for barge-in. Turn off for a raw-echo control baseline.
+- **Voice mode** — band-passes the AEC output to the AEC's working band so the server VAD only hears near-end speech (removes the out-of-band residual echo the VAD would otherwise trip on).
 
 ## Notes
 

--- a/flutter/packages/simple_brilliant_app/example/realtime_openai/android/app/src/main/AndroidManifest.xml
+++ b/flutter/packages/simple_brilliant_app/example/realtime_openai/android/app/src/main/AndroidManifest.xml
@@ -16,6 +16,11 @@
     <!-- legacy for Android 9 or lower -->
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" android:maxSdkVersion="28" />
 
+    <!-- Required to reach the Realtime endpoint (wss://). Flutter's debug/profile
+         manifests add INTERNET automatically, but release builds use this main
+         manifest, so it must be declared here or release builds can't connect. -->
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:label="realtime_openai"
         android:name="${applicationName}"

--- a/flutter/packages/simple_brilliant_app/example/realtime_openai/assets/frame_app.lua
+++ b/flutter/packages/simple_brilliant_app/example/realtime_openai/assets/frame_app.lua
@@ -22,7 +22,9 @@ local parsers = {}
 parsers[CLEAR_MSG] = code.parse_code
 parsers[CLICK_SUBS_MSG] = code.parse_code
 parsers[TEXT_MSG] = plain_text.parse_plain_text
-parsers[START_LISTENING_MSG] = code.parse_code
+-- START_LISTENING carries three named config bytes (see its handler), not a
+-- single code, so it takes the raw payload straight through.
+parsers[START_LISTENING_MSG] = function(raw) return raw end
 parsers[STOP_LISTENING_MSG] = code.parse_code
 parsers[START_PLAYBACK_MSG] = code.parse_code
 parsers[STOP_PLAYBACK_MSG] = code.parse_code
@@ -82,14 +84,23 @@ handlers[CLICK_SUBS_MSG] = function(parsed_data)
 	end
 end
 
-handlers[START_LISTENING_MSG] = function(parsed_data)
-	-- Halo-only: stream LC3-encoded microphone audio
-	-- value carries the mic gain offset by +10 (0..20 -> gain -10..10)
-	local gain = 0
-	if parsed_data.value ~= nil and parsed_data.value >= 0 and parsed_data.value <= 20 then
-		gain = parsed_data.value - 10
+handlers[START_LISTENING_MSG] = function(raw)
+	-- Halo-only: stream LC3-encoded microphone audio at 16kHz mono.
+	-- Payload is three named bytes (see main.dart _micStartPayload):
+	--   [1] gain code 0..20  -> mic gain -10..10  ([1] - 10)
+	--   [2] aec   0/1         -> echo cancellation on/off
+	--   [3] voice 0/1         -> voice-band mode on/off (band-pass the AEC
+	--                            output, so the server VAD only hears near-end)
+	local gain, aec_on, voice = 0, true, false
+	if raw ~= nil and #raw >= 3 then
+		gain = string.byte(raw, 1) - 10
+		aec_on = string.byte(raw, 2) ~= 0
+		voice = string.byte(raw, 3) ~= 0
 	end
+	if gain < -10 then gain = -10 elseif gain > 10 then gain = 10 end
 	pcall(frame.microphone.start, {encoder='lc3', sample_rate=16000, bitrate=32000, channels=1, gain=gain})
+	pcall(frame.microphone.aec, aec_on)
+	pcall(frame.microphone.voice, voice)
 	listening = true
 end
 

--- a/flutter/packages/simple_brilliant_app/example/realtime_openai/ios/Runner/Info.plist
+++ b/flutter/packages/simple_brilliant_app/example/realtime_openai/ios/Runner/Info.plist
@@ -26,6 +26,16 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<!-- This is a developer SDK example, not an App Store app. Allow cleartext
+	     (ws:// / http://) connections so it can reach a local, non-TLS backend
+	     such as the huggingface/speech-to-speech server (ws://<host>:8765), whose
+	     address is dynamic and so can't be scoped to a fixed exception domain.
+	     The default wss:// OpenAI endpoint does not need this. -->
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>NSBluetoothAlwaysUsageDescription</key>
 	<string>This app needs Bluetooth to function</string>
 	<key>UIApplicationSceneManifest</key>

--- a/flutter/packages/simple_brilliant_app/example/realtime_openai/lib/main.dart
+++ b/flutter/packages/simple_brilliant_app/example/realtime_openai/lib/main.dart
@@ -32,6 +32,10 @@ const lc3SampleRate = 16000;
 const lc3Bitrate = 32000;
 const lc3FrameDurationUs = 10000;
 
+/// bytes per encoded LC3 frame (32kbps, 10ms -> 40 bytes); used to count how
+/// many 10ms frames are in each packet sent to the device, for the playback clock
+const lc3FrameBytes = lc3Bitrate ~/ 8 * lc3FrameDurationUs ~/ 1000000;
+
 /// send mic audio in ~40-60ms batches (rather than per 10ms frame)
 const micBatchBytes = 1920;
 
@@ -46,11 +50,18 @@ const haloMicGainValue = 10;
 const defaultEndpoint = 'wss://api.openai.com/v1/realtime?model=gpt-realtime';
 
 
-/// one entry in the conversation transcript
+/// one entry (chat bubble) in the conversation transcript
 class TranscriptEntry {
   final bool fromUser;
   String text;
-  TranscriptEntry(this.fromUser, this.text);
+
+  /// turn id this bubble belongs to (response id for the model, input item id
+  /// for the user; null on backends that don't tag events). Used to keep two
+  /// same-speaker turns in separate bubbles even when their transcripts arrive
+  /// back-to-back or out of order.
+  final String? turnId;
+
+  TranscriptEntry(this.fromUser, this.text, [this.turnId]);
 }
 
 class MainApp extends StatefulWidget {
@@ -123,9 +134,10 @@ class MainAppState extends State<MainApp> with SimpleFrameAppState {
       onAudio: _handleOpenAiAudio,
       onInterrupted: _handleOpenAiInterrupted,
       isPlaybackPending: () => _conversing && (_pacer?.bufferedFrames ?? 0) > 0,
-      onInputTranscript: (text) => _appendTranscript(fromUser: true, text: text),
-      onOutputTranscript: (text) =>
-          _appendTranscript(fromUser: false, text: text),
+      onInputTranscript: (text, id) =>
+          _appendTranscript(fromUser: true, text: text, turnId: id),
+      onOutputTranscript: (text, id) =>
+          _appendTranscript(fromUser: false, text: text, turnId: id),
       onTurnComplete: _handleTurnComplete,
       onEvent: _logEvent,
     );
@@ -219,6 +231,14 @@ class MainAppState extends State<MainApp> with SimpleFrameAppState {
         return;
       }
 
+      // If the user pressed cancel (FAB) while we were connecting, cancel() has
+      // already torn down and set the state - don't proceed and resurrect the
+      // session with zombie click/display subscriptions.
+      if (currentState != ApplicationState.running) {
+        await _openai.disconnect();
+        return;
+      }
+
       // Halo button starts/stops the conversation
       await _clickSubs?.cancel();
       _clickSubs = RxClick().attach(frame!.dataResponse).listen(_handleClick);
@@ -233,7 +253,9 @@ class MainAppState extends State<MainApp> with SimpleFrameAppState {
     } catch (e) {
       _log.severe('Error starting realtime session: $e');
       await _openai.disconnect();
-      setState(() => currentState = ApplicationState.ready);
+      // always return to ready so the FAB/footer aren't stuck disabled after a
+      // failed connect (e.g. a bad endpoint URL)
+      if (mounted) setState(() => currentState = ApplicationState.ready);
     }
   }
 
@@ -242,15 +264,25 @@ class MainAppState extends State<MainApp> with SimpleFrameAppState {
     setState(() => currentState = ApplicationState.canceling);
 
     _displayTimer?.cancel();
-    await _stopConversation();
-    await _openai.disconnect();
+    try {
+      await _stopConversation();
+      await _openai.disconnect();
 
-    await frame!.sendMessage(clickSubsMsg, TxCode(value: 0).pack());
-    await _clickSubs?.cancel();
-    _clickSubs = null;
-    await frame!.sendMessage(clearMsg, TxCode().pack());
-
-    setState(() => currentState = ApplicationState.ready);
+      // Best-effort, timed-out device cleanup: a hung write here must not block
+      // the `finally` below, or the app stays stuck in `canceling`.
+      await _bleBestEffort('unsubscribe clicks',
+          () => frame!.sendMessage(clickSubsMsg, TxCode(value: 0).pack()));
+      await _clickSubs?.cancel();
+      _clickSubs = null;
+      await _bleBestEffort('clear display',
+          () => frame!.sendMessage(clearMsg, TxCode().pack()));
+    } catch (e) {
+      _log.warning('Error during cancel: $e');
+    } finally {
+      // always return to ready, even if teardown partially failed, so the
+      // FAB/footer don't stay stuck in the disabled `canceling` state
+      if (mounted) setState(() => currentState = ApplicationState.ready);
+    }
   }
 
   void _handleClick(ClickType type) {
@@ -304,7 +336,19 @@ class MainAppState extends State<MainApp> with SimpleFrameAppState {
     _pacer = Lc3PacketPacer(
       intervalMs: lc3FrameDurationUs ~/ 1000,
       maxBufferDelayFrames: 6000, // cap phone-side buffer at 60s of audio
-      sendAudio: (data) async => frame!.sendAudio(data),
+      sendAudio: (data) async {
+        await frame!.sendAudio(data);
+        // Advance the playback clock by the real-time duration of what we just
+        // sent to the device (each LC3 frame is 10ms). This is the true "audio
+        // sent to the device" point, so the barge gate stays armed for the whole
+        // physical playout instead of reopening the instant the client queue
+        // drains (which would leak the reply's tail to the server).
+        final nFrames = data.lengthInBytes ~/ lc3FrameBytes;
+        if (nFrames > 0) {
+          _openai.advancePlaybackClock(
+              Duration(microseconds: lc3FrameDurationUs * nFrames));
+        }
+      },
     );
     _speakerLc3Subs = _speakerEncoder!.outputStream
         .listen((lc3Frame) => _pacer?.onNewPacketReceived(lc3Frame));
@@ -332,13 +376,27 @@ class MainAppState extends State<MainApp> with SimpleFrameAppState {
       Uint8List.fromList(
           [gain.clamp(0, 20), aec ? 1 : 0, voice ? 1 : 0]);
 
-  Future<void> _stopAudioPipeline() async {
+  /// Run a best-effort BLE teardown step: bounded by a timeout and swallowing
+  /// errors, so a hung or failed device write can never block teardown from
+  /// reaching its terminal state. Without this, a stalled write leaves the app
+  /// parked in a transient state (`canceling`/`stopping`) where the FAB is gone
+  /// and every footer button is disabled - with no way out.
+  Future<void> _bleBestEffort(String what, Future<void> Function() op) async {
     try {
-      await frame!.sendMessage(stopListeningMsg, TxCode().pack());
-      await frame!.sendMessage(stopPlaybackMsg, TxCode().pack());
+      await op().timeout(const Duration(seconds: 2));
     } catch (e) {
-      _log.warning('Error stopping device audio: $e');
+      _log.warning('$what failed/timed out during teardown: $e');
     }
+  }
+
+  Future<void> _stopAudioPipeline() async {
+    // Timed-out so a degraded BLE link can't hang teardown (which would strand
+    // the app in a transient state where the FAB and all footer buttons are
+    // disabled). See [_bleBestEffort].
+    await _bleBestEffort('stop listening',
+        () => frame!.sendMessage(stopListeningMsg, TxCode().pack()));
+    await _bleBestEffort('stop playback',
+        () => frame!.sendMessage(stopPlaybackMsg, TxCode().pack()));
 
     await _micLc3Subs?.cancel();
     _micLc3Subs = null;
@@ -423,14 +481,20 @@ class MainAppState extends State<MainApp> with SimpleFrameAppState {
     _displayDirty = true;
   }
 
-  /// accumulate incremental transcription fragments into per-speaker entries
-  void _appendTranscript({required bool fromUser, required String text}) {
+  /// accumulate incremental transcription fragments into per-turn bubbles. A
+  /// fragment extends the last bubble only when it is the same speaker AND the
+  /// same turn id; otherwise it starts a new bubble. Keying on the turn id (as
+  /// well as the speaker) keeps the next reply from being appended to the
+  /// previous bubble when transcripts arrive back-to-back or out of order.
+  void _appendTranscript(
+      {required bool fromUser, required String text, String? turnId}) {
     if (!mounted) return;
     setState(() {
-      if (_transcript.isNotEmpty && _transcript.last.fromUser == fromUser) {
-        _transcript.last.text += text;
+      final last = _transcript.isNotEmpty ? _transcript.last : null;
+      if (last != null && last.fromUser == fromUser && last.turnId == turnId) {
+        last.text += text;
       } else {
-        _transcript.add(TranscriptEntry(fromUser, text));
+        _transcript.add(TranscriptEntry(fromUser, text, turnId));
       }
     });
 

--- a/flutter/packages/simple_brilliant_app/example/realtime_openai/lib/main.dart
+++ b/flutter/packages/simple_brilliant_app/example/realtime_openai/lib/main.dart
@@ -88,7 +88,14 @@ class MainAppState extends State<MainApp> with SimpleFrameAppState {
 
   // conversation state
   bool _conversing = false;
-  bool _allowBargeIn = false;
+
+  // on-device audio processing (applied at mic start). Full-duplex barge-in
+  // relies on the AEC to strip the Halo speaker's bleed out of the mic, and on
+  // voice mode to band-pass the AEC output so the server VAD only hears the
+  // near-end - matching the Python sample's defaults (--aec-off / --no-voice-mode
+  // turn them off there).
+  bool _aec = true;
+  bool _voiceMode = true;
 
   final List<TranscriptEntry> _transcript = [];
   final List<String> _eventLog = [];
@@ -115,6 +122,7 @@ class MainAppState extends State<MainApp> with SimpleFrameAppState {
     _openai = OpenAiRealtime(
       onAudio: _handleOpenAiAudio,
       onInterrupted: _handleOpenAiInterrupted,
+      isPlaybackPending: () => _conversing && (_pacer?.bufferedFrames ?? 0) > 0,
       onInputTranscript: (text) => _appendTranscript(fromUser: true, text: text),
       onOutputTranscript: (text) =>
           _appendTranscript(fromUser: false, text: text),
@@ -311,9 +319,18 @@ class MainAppState extends State<MainApp> with SimpleFrameAppState {
 
     await frame!.sendMessage(
         startPlaybackMsg, TxCode(value: haloSpeakerVolume).pack());
-    await frame!.sendMessage(
-        startListeningMsg, TxCode(value: haloMicGainValue).pack());
+    await frame!.sendMessage(startListeningMsg,
+        _micStartPayload(gain: haloMicGainValue, aec: _aec, voice: _voiceMode));
   }
+
+  /// START_LISTENING payload: three named bytes, one field each, decoded by the
+  /// frame app's START_LISTENING handler:
+  ///   [0] gain code 0..20 (10 = 0 dB)   [1] aec 0/1   [2] voice 0/1
+  /// Maps 1:1 onto frame.microphone.start{gain=}, .aec(bool), .voice(bool).
+  Uint8List _micStartPayload(
+          {required int gain, required bool aec, required bool voice}) =>
+      Uint8List.fromList(
+          [gain.clamp(0, 20), aec ? 1 : 0, voice ? 1 : 0]);
 
   Future<void> _stopAudioPipeline() async {
     try {
@@ -366,16 +383,12 @@ class MainAppState extends State<MainApp> with SimpleFrameAppState {
   }
 
   /// decoded PCM microphone audio (already at the endpoint's sample rate):
-  /// batch and forward. Without acoustic echo cancellation the Halo mic hears
-  /// the Halo speaker, so by default the mic is muted while response audio is
-  /// playing (half-duplex). Enable barge-in to keep the mic open and let the
-  /// server's voice activity detection interrupt the response instead.
+  /// batch and forward. Full-duplex: the mic streams continuously, even while
+  /// a reply is playing, so the user can talk over it to interrupt (barge-in).
+  /// The on-device AEC strips the Halo speaker's bleed out of the mic feed, so
+  /// this is (mostly) near-end speech and the server VAD won't self-interrupt.
   void _handleMicPcm(Uint8List pcmFrame) {
     if (!_conversing) return;
-    if (!_allowBargeIn && (_pacer?.bufferedFrames ?? 0) > 0) {
-      _micPcmBatch.clear();
-      return;
-    }
 
     _micPcmBatch.add(pcmFrame);
     if (_micPcmBatch.length >= micBatchBytes) {
@@ -545,11 +558,26 @@ class MainAppState extends State<MainApp> with SimpleFrameAppState {
               SwitchListTile(
                 dense: true,
                 contentPadding: EdgeInsets.zero,
-                title: const Text(
-                    'Allow barge-in (mic stays open during replies - '
-                    'no echo cancellation yet)'),
-                value: _allowBargeIn,
-                onChanged: (v) => setState(() => _allowBargeIn = v),
+                title: const Text('Echo cancellation (AEC)'),
+                subtitle: const Text(
+                    'On-device AEC removes the speaker bleed so the mic can '
+                    'stay open for barge-in'),
+                value: _aec,
+                onChanged: _conversing
+                    ? null
+                    : (v) => setState(() => _aec = v),
+              ),
+              SwitchListTile(
+                dense: true,
+                contentPadding: EdgeInsets.zero,
+                title: const Text('Voice mode'),
+                subtitle: const Text(
+                    'Band-pass the AEC output so the server VAD only hears '
+                    'near-end speech'),
+                value: _voiceMode,
+                onChanged: _conversing
+                    ? null
+                    : (v) => setState(() => _voiceMode = v),
               ),
               if (currentState == ApplicationState.running)
                 Card(

--- a/flutter/packages/simple_brilliant_app/example/realtime_openai/lib/openai_realtime.dart
+++ b/flutter/packages/simple_brilliant_app/example/realtime_openai/lib/openai_realtime.dart
@@ -42,6 +42,25 @@ class OpenAiRealtime {
   bool _connected = false;
   bool _sessionReady = false;
 
+  /// a reply is currently being generated (tracked off both response.created
+  /// and the audio deltas, since some backends - e.g. jarvis in server-VAD mode
+  /// - auto-create replies without emitting response.created)
+  bool _responseActive = false;
+
+  /// the user has barged in over the current reply: drop its trailing audio
+  /// deltas (the server can't unsend audio it already streamed to us)
+  bool _barged = false;
+
+  /// response id of the reply currently streaming audio (may be null on
+  /// backends that don't tag deltas, e.g. jarvis)
+  String? _currentResponseId;
+
+  /// response id we cancelled on barge-in. While barged, only deltas from THIS
+  /// id are dropped; a delta from a new id (or any delta when ids are absent)
+  /// clears the barge and plays - so the latch can never get stuck silencing
+  /// every future reply if the backend omits response.done/created.
+  String? _cancelledResponseId;
+
   /// true once the input transcription arrived as incremental deltas, so the
   /// terminal `.completed` transcript can be ignored (avoids duplication)
   bool _sawInputTranscriptDelta = false;
@@ -55,6 +74,12 @@ class OpenAiRealtime {
 
   /// the user spoke over the model: discard all buffered response audio
   final void Function() onInterrupted;
+
+  /// true while response audio is still queued/playing on the phone or device.
+  /// The barge-in logic needs this because a reply keeps playing out of the
+  /// local buffer after the server has finished streaming it: the split analog
+  /// of the Python sample's `_playback_pending()`.
+  final bool Function()? isPlaybackPending;
 
   /// transcription of the user's speech (incremental fragments)
   final void Function(String text)? onInputTranscript;
@@ -70,6 +95,7 @@ class OpenAiRealtime {
   OpenAiRealtime({
     required this.onAudio,
     required this.onInterrupted,
+    this.isPlaybackPending,
     this.onInputTranscript,
     this.onOutputTranscript,
     this.onTurnComplete,
@@ -128,7 +154,13 @@ class OpenAiRealtime {
           'input': {
             'format': {'type': 'audio/pcm', 'rate': serverSampleRate},
             'transcription': {'model': 'whisper-1'},
-            'turn_detection': {'type': 'server_vad'},
+            // interrupt_response lets the server stop generating on a barge-in;
+            // the client still flushes its own queued playback (below), since
+            // the server can't cancel audio it has already streamed to us.
+            'turn_detection': {
+              'type': 'server_vad',
+              'interrupt_response': true,
+            },
           },
           'output': {
             'format': {'type': 'audio/pcm', 'rate': serverSampleRate},
@@ -159,6 +191,11 @@ class OpenAiRealtime {
     _connected = false;
     _sessionReady = false;
     _sawInputTranscriptDelta = false;
+    _sawOutputTranscriptDelta = false;
+    _responseActive = false;
+    _barged = false;
+    _currentResponseId = null;
+    _cancelledResponseId = null;
     await _channelSubs?.cancel();
     _channelSubs = null;
     await _channel?.sink.close();
@@ -191,8 +228,31 @@ class OpenAiRealtime {
         }
         break;
 
+      case 'response.created':
+        _responseActive = true;
+        _barged = false;
+        _cancelledResponseId = null;
+        _currentResponseId = event['response']?['id'] as String?;
+        break;
+
       // response audio chunk (PCM16 at the endpoint's sample rate)
       case 'response.output_audio.delta':
+        final rid = event['response_id'] as String?;
+        if (_barged) {
+          // drop ONLY the cancelled reply's tail; a delta from a new reply (or
+          // any delta when the backend omits ids) means the barge is over
+          final isCancelledTail = rid != null &&
+              _cancelledResponseId != null &&
+              rid == _cancelledResponseId;
+          if (isCancelledTail) break;
+          _barged = false;
+          _cancelledResponseId = null;
+        }
+        // Track the active reply off the audio stream, not just
+        // response.created: some backends (e.g. jarvis in server-VAD mode)
+        // never emit response.created for auto-created replies.
+        _currentResponseId = rid;
+        _responseActive = true;
         final delta = event['delta'] as String?;
         if (delta != null) onAudio(base64Decode(delta));
         break;
@@ -235,15 +295,35 @@ class OpenAiRealtime {
         _sawInputTranscriptDelta = false;
         break;
 
-      // barge-in: the server's VAD detected the user speaking; drop queued
-      // response audio (the server cancels its own in-flight response)
+      // barge-in: the server's VAD detected the user speaking over a reply.
+      // The on-device AEC keeps the assistant's own voice out of the mic, so a
+      // speech_started while a reply is playing is the user talking. Cancel the
+      // server's reply and flush the queued playback (the server can't unsend
+      // audio it already streamed to us, so the client must drain its buffer).
       case 'input_audio_buffer.speech_started':
-        _event('---Interrupted---');
-        onInterrupted();
+        final pending = _responseActive || (isPlaybackPending?.call() ?? false);
+        if (!_barged && pending) {
+          // latch `barged` (to drop trailing deltas) only if a reply is still
+          // generating; if it already completed there is no tail to drop and
+          // latching would wrongly mute the next reply. Tag the cancelled reply
+          // by id so only its tail is dropped.
+          _barged = _responseActive;
+          _cancelledResponseId = _responseActive ? _currentResponseId : null;
+          _event('---Interrupted---');
+          _channel?.sink.add(jsonEncode({'type': 'response.cancel'}));
+          onInterrupted();
+        }
         break;
 
       case 'response.done':
+        _responseActive = false;
         _sawOutputTranscriptDelta = false;
+        // Clear the barge latch so the NEXT reply plays. The queued playback was
+        // already flushed at barge-in and the cancelled reply's tail deltas are
+        // dropped by id, so there is nothing left to flush here.
+        _barged = false;
+        _cancelledResponseId = null;
+        _currentResponseId = null;
         onTurnComplete?.call();
         break;
 

--- a/flutter/packages/simple_brilliant_app/example/realtime_openai/lib/openai_realtime.dart
+++ b/flutter/packages/simple_brilliant_app/example/realtime_openai/lib/openai_realtime.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
+import 'dart:collection';
 import 'dart:convert';
+import 'dart:math' as math;
 import 'dart:typed_data';
 
 import 'package:logging/logging.dart';
@@ -42,10 +44,40 @@ class OpenAiRealtime {
   bool _connected = false;
   bool _sessionReady = false;
 
-  /// a reply is currently being generated (tracked off both response.created
-  /// and the audio deltas, since some backends - e.g. jarvis in server-VAD mode
-  /// - auto-create replies without emitting response.created)
-  bool _responseActive = false;
+  /// after this long with no new reply audio, treat the reply as no longer
+  /// streaming. Used instead of a sticky "response active" flag: some backends
+  /// (e.g. jarvis in server-VAD mode) send neither response.created nor
+  /// response.done, so a flag keyed on those would stick and make every later
+  /// user turn spuriously barge.
+  static const Duration _playbackIdle = Duration(seconds: 1);
+
+  /// time the last reply audio delta arrived (null if none yet / reply ended)
+  DateTime? _lastAudioTime;
+
+  /// Playback clock: the time the DEVICE finishes physically playing out
+  /// everything sent to it so far. Advanced by [advancePlaybackClock] from the
+  /// pacer (the true "audio sent to the device" point) - NOT from when a delta
+  /// was received. The client streams a reply to the device faster than it plays
+  /// (generation finishes in ~1-2s; playout takes several real-time seconds), so
+  /// keying "is a reply playing?" on the client queue reopens the mic gate-off
+  /// mid-playout and leaks the reply's tail to the server. Init to the epoch.
+  DateTime _playUntil = DateTime.fromMillisecondsSinceEpoch(0);
+
+  /// How long after [_playUntil] a reply still counts as playing, covering the
+  /// on-device / in-flight buffer latency (the device buffers a few hundred ms
+  /// ahead of the speaker). Matches the Python sample's PLAYBACK_TAIL_S.
+  static const Duration _playbackTail = Duration(milliseconds: 600);
+
+  // --- RMS barge-in gate (see [bargeRms]) -------------------------------------
+  // While a reply is playing, hold the mic closed to the server and open it only
+  // once the near-end AC-RMS confirms the wearer is talking OVER it, so the
+  // assistant's post-AEC echo residual can't be transcribed as a phantom turn and
+  // spiral on a sensitive server VAD. Ported verbatim from the Python sample.
+  bool _gateOpen = false; // currently forwarding near-end during playback
+  int _gateHot = 0; // consecutive above-threshold reads (to open)
+  double _gatePeak = 0; // loudest read while arming (logged on open)
+  double _gateQuietMs = 0; // accumulated sub-threshold audio (to close)
+  final Queue<Uint8List> _preroll = ListQueue(); // onset back-fill on open
 
   /// the user has barged in over the current reply: drop its trailing audio
   /// deltas (the server can't unsend audio it already streamed to us)
@@ -81,16 +113,36 @@ class OpenAiRealtime {
   /// of the Python sample's `_playback_pending()`.
   final bool Function()? isPlaybackPending;
 
-  /// transcription of the user's speech (incremental fragments)
-  final void Function(String text)? onInputTranscript;
+  /// transcription of the user's speech (incremental fragments). [turnId] is the
+  /// input item id (null on backends that don't tag events); consecutive
+  /// fragments sharing a turnId belong to the same utterance / chat bubble.
+  final void Function(String text, String? turnId)? onInputTranscript;
 
-  /// transcription of the model's speech (incremental fragments)
-  final void Function(String text)? onOutputTranscript;
+  /// transcription of the model's speech (incremental fragments). [turnId] is
+  /// the response id (null on backends that don't tag events); consecutive
+  /// fragments sharing a turnId belong to the same reply / chat bubble.
+  final void Function(String text, String? turnId)? onOutputTranscript;
 
   final void Function()? onTurnComplete;
 
   /// connection state changes and other noteworthy events, for the UI log
   final void Function(String event)? onEvent;
+
+  /// RMS barge-in gate: near-end AC-RMS a mic read must clear to open the mic to
+  /// the server WHILE a reply is playing, so the assistant's echo can't
+  /// self-interrupt a sensitive server VAD. Worn-tuned: real barges opened at
+  /// 475-1700, a stray echo/hallucination open landed ~337, so 400 sits in the
+  /// gap. `bargeRms <= 0` disables the gate entirely (full duplex - use for a
+  /// backend that doesn't trip on the residual, e.g. jarvis/Silero).
+  final double bargeRms;
+
+  /// consecutive above-threshold mic reads needed to open the gate (debounce;
+  /// higher = fewer false barges, slightly slower onset). Clamped to >= 1.
+  final int confirmFrames;
+
+  /// sub-threshold audio after which an open gate re-closes (keep short so it
+  /// doesn't forward echo into the next reply)
+  final double hangoverMs;
 
   OpenAiRealtime({
     required this.onAudio,
@@ -100,7 +152,13 @@ class OpenAiRealtime {
     this.onOutputTranscript,
     this.onTurnComplete,
     this.onEvent,
+    this.bargeRms = 400.0,
+    this.confirmFrames = 3,
+    this.hangoverMs = 400.0,
   });
+
+  /// [confirmFrames] with the Python sample's `max(1, ...)` floor applied
+  int get _confirmFrames => confirmFrames < 1 ? 1 : confirmFrames;
 
   bool get isConnected => _connected;
 
@@ -127,7 +185,17 @@ class OpenAiRealtime {
     };
 
     _channel = IOWebSocketChannel.connect(Uri.parse(endpoint), headers: headers);
-    await _channel!.ready;
+    // Bound the handshake: an unreachable host / bad endpoint can otherwise leave
+    // `.ready` pending indefinitely, stranding the caller in its "connecting"
+    // (running) state with only a cancel FAB. On timeout or refusal, fail cleanly
+    // so the caller can return to a usable state.
+    try {
+      await _channel!.ready.timeout(const Duration(seconds: 10));
+    } catch (e) {
+      _event('Failed to open connection: $e');
+      await disconnect();
+      return false;
+    }
 
     _channelSubs = _channel!.stream.listen(
       _handleServerMessage,
@@ -157,8 +225,13 @@ class OpenAiRealtime {
             // interrupt_response lets the server stop generating on a barge-in;
             // the client still flushes its own queued playback (below), since
             // the server can't cancel audio it has already streamed to us.
+            // threshold (default 0.5) is raised to 0.6 so the assistant's own
+            // residual echo (post-AEC bleed) is less likely to trip the VAD and
+            // self-interrupt; raise further if it still self-interrupts, lower
+            // if it misses genuine barge-ins.
             'turn_detection': {
               'type': 'server_vad',
+              'threshold': 0.6,
               'interrupt_response': true,
             },
           },
@@ -192,27 +265,158 @@ class OpenAiRealtime {
     _sessionReady = false;
     _sawInputTranscriptDelta = false;
     _sawOutputTranscriptDelta = false;
-    _responseActive = false;
+    _lastAudioTime = null;
     _barged = false;
     _currentResponseId = null;
     _cancelledResponseId = null;
-    await _channelSubs?.cancel();
+    _playUntil = DateTime.fromMillisecondsSinceEpoch(0);
+    _resetGate();
+    // Never throw: closing a channel whose connection failed (e.g. a bad URL,
+    // where `.ready` threw) can raise, and callers reset UI state after this -
+    // an exception here must not prevent that.
+    try {
+      await _channelSubs?.cancel().timeout(const Duration(seconds: 2));
+    } catch (_) {}
     _channelSubs = null;
-    await _channel?.sink.close();
+    try {
+      // Bounded: closing a websocket sink whose `.ready` rejected (e.g. the
+      // connection was refused - wrong host/port) can hang forever, which would
+      // stall connect()'s own cleanup and any cancel()/teardown that awaits this,
+      // stranding the app in a transient state with no usable controls.
+      await _channel?.sink.close().timeout(const Duration(seconds: 2));
+    } catch (_) {}
     _channel = null;
   }
 
   /// Append a chunk of PCM16 mono audio (at the endpoint's sample rate) to the
-  /// input buffer. Server-side VAD handles commit + response creation.
+  /// input buffer, RMS-gated during playback. Server-side VAD handles commit +
+  /// response creation.
+  ///
+  /// With the gate disabled ([bargeRms] <= 0) or when no reply is playing, the
+  /// mic streams straight through - normal full-duplex listening / turn-taking.
+  /// While a reply IS playing, the mic is held closed and only opened once the
+  /// near-end AC-RMS clears the gate for [confirmFrames] consecutive reads, so
+  /// the server never hears (and so never transcribes and answers) the
+  /// assistant's own echo. On open we back-fill the buffered onset so the barge's
+  /// first word isn't clipped; the gate then stays open through the utterance,
+  /// re-closing after [hangoverMs] of near-silence. Ported from the Python
+  /// sample's `_forward_mic`.
   void sendAudio(Uint8List pcm) {
     if (!_sessionReady) return;
 
-    final msg = {
+    if (bargeRms <= 0 || !_playbackPending) {
+      // gate disabled, or nothing playing: stream through; reset gate state
+      _resetGate();
+      _sendMic(pcm);
+      return;
+    }
+
+    // DC-removed (AC) RMS: the echo residual is low-energy post-AEC even though
+    // it is speech-shaped, so measure ENERGY (std), not level (see [bargeRms]).
+    final rms = _acRms(pcm);
+    final nSamples = pcm.lengthInBytes ~/ 2;
+    final durMs = 1000.0 * nSamples / serverSampleRate;
+
+    if (_gateOpen) {
+      // stay open through the utterance; close after a beat of near-silence
+      if (rms < bargeRms) {
+        _gateQuietMs += durMs;
+      } else {
+        _gateQuietMs = 0;
+      }
+      if (_gateQuietMs < hangoverMs) {
+        _sendMic(pcm);
+        return;
+      }
+      _gateOpen = false; // fell quiet: re-close and re-arm below
+      _gateHot = 0;
+      _gateQuietMs = 0;
+    }
+
+    // gate closed: buffer the onset and count consecutive above-threshold reads
+    _preroll.addLast(pcm);
+    while (_preroll.length > _confirmFrames) {
+      _preroll.removeFirst();
+    }
+    if (rms >= bargeRms) {
+      _gateHot += 1;
+      _gatePeak = math.max(_gatePeak, rms);
+    } else {
+      _gateHot = 0;
+      _gatePeak = 0;
+    }
+    if (_gateHot >= _confirmFrames) {
+      // confirmed near-end: open, back-fill the buffered onset, then stream.
+      // Log the RMS that opened it: an open near the threshold (rather than well
+      // above it) is echo leaking through - raise [bargeRms] if so.
+      _event('[gate open] near-end rms=${_gatePeak.toStringAsFixed(0)}');
+      _gateOpen = true;
+      _gateQuietMs = 0;
+      _gateHot = 0;
+      _gatePeak = 0;
+      for (final buffered in _preroll) {
+        _sendMic(buffered);
+      }
+      _preroll.clear();
+    }
+    // else: closed + unconfirmed -> drop this block (echo-only); the server
+    // never sees it, so it can't spiral
+  }
+
+  /// Actually append a mic block to the server input buffer (post-gate).
+  void _sendMic(Uint8List pcm) {
+    if (!_sessionReady) return;
+    _channel!.sink.add(jsonEncode({
       'type': 'input_audio_buffer.append',
       'audio': base64Encode(pcm),
-    };
-    _channel!.sink.add(jsonEncode(msg));
+    }));
   }
+
+  void _resetGate() {
+    _gateOpen = false;
+    _gateHot = 0;
+    _gatePeak = 0;
+    _gateQuietMs = 0;
+    _preroll.clear();
+  }
+
+  /// DC-removed (AC) RMS over a PCM16 block: the standard deviation of the
+  /// samples. Dart has no numpy, so compute it directly.
+  double _acRms(Uint8List pcm) {
+    final s = Int16List.view(
+        pcm.buffer, pcm.offsetInBytes, pcm.lengthInBytes ~/ 2);
+    if (s.length < 2) return 0;
+    double mean = 0;
+    for (final v in s) {
+      mean += v;
+    }
+    mean /= s.length;
+    double sq = 0;
+    for (final v in s) {
+      final d = v - mean;
+      sq += d * d;
+    }
+    return math.sqrt(sq / s.length);
+  }
+
+  /// Advance the playback clock by [sent] - the real-time duration of the audio
+  /// just dispatched to the DEVICE (fed from the pacer, the true "audio sent to
+  /// the device" point). The barge gate stays armed for the whole physical
+  /// playout, not just while the client queue is non-empty. See [_playUntil].
+  void advancePlaybackClock(Duration sent) {
+    final now = DateTime.now();
+    _playUntil = (_playUntil.isAfter(now) ? _playUntil : now).add(sent);
+  }
+
+  /// True while the DEVICE is still playing a reply out (not merely while the
+  /// client still holds audio): the injected queue check is a floor for the
+  /// instant between enqueue and the first device send, ORed with the playback
+  /// clock (+[_playbackTail]) which covers the physical playout the client
+  /// queue has already drained ahead of. Split analog of the Python sample's
+  /// `_playback_pending()`.
+  bool get _playbackPending =>
+      (isPlaybackPending?.call() ?? false) ||
+      DateTime.now().isBefore(_playUntil.add(_playbackTail));
 
   void _handleServerMessage(dynamic message) {
     final event = jsonDecode(
@@ -229,7 +433,6 @@ class OpenAiRealtime {
         break;
 
       case 'response.created':
-        _responseActive = true;
         _barged = false;
         _cancelledResponseId = null;
         _currentResponseId = event['response']?['id'] as String?;
@@ -248,21 +451,22 @@ class OpenAiRealtime {
           _barged = false;
           _cancelledResponseId = null;
         }
-        // Track the active reply off the audio stream, not just
-        // response.created: some backends (e.g. jarvis in server-VAD mode)
-        // never emit response.created for auto-created replies.
+        // Mark the reply streaming off the audio stream (see _recentAudio):
+        // some backends (e.g. jarvis in server-VAD mode) send neither
+        // response.created nor response.done, so a fresh delta is the only
+        // reliable "a reply is playing" signal.
         _currentResponseId = rid;
-        _responseActive = true;
+        _lastAudioTime = DateTime.now();
         final delta = event['delta'] as String?;
         if (delta != null) onAudio(base64Decode(delta));
         break;
 
-      // model speech transcript (incremental)
+      // model speech transcript (incremental); key the bubble by response id
       case 'response.output_audio_transcript.delta':
         final delta = event['delta'] as String?;
         if (delta != null) {
           _sawOutputTranscriptDelta = true;
-          onOutputTranscript?.call(delta);
+          onOutputTranscript?.call(delta, _outputTurnId(event));
         }
         break;
 
@@ -272,16 +476,17 @@ class OpenAiRealtime {
       case 'response.output_audio_transcript.done':
         final transcript = event['transcript'] as String?;
         if (transcript != null && !_sawOutputTranscriptDelta) {
-          onOutputTranscript?.call(transcript);
+          onOutputTranscript?.call(transcript, _outputTurnId(event));
         }
         break;
 
-      // user speech transcript (incremental, when the backend streams it)
+      // user speech transcript (incremental, when the backend streams it); key
+      // the bubble by input item id
       case 'conversation.item.input_audio_transcription.delta':
         final delta = event['delta'] as String?;
         if (delta != null) {
           _sawInputTranscriptDelta = true;
-          onInputTranscript?.call(delta);
+          onInputTranscript?.call(delta, event['item_id'] as String?);
         }
         break;
 
@@ -290,40 +495,45 @@ class OpenAiRealtime {
       case 'conversation.item.input_audio_transcription.completed':
         final transcript = event['transcript'] as String?;
         if (transcript != null && !_sawInputTranscriptDelta) {
-          onInputTranscript?.call(transcript);
+          onInputTranscript?.call(transcript, event['item_id'] as String?);
         }
         _sawInputTranscriptDelta = false;
         break;
 
       // barge-in: the server's VAD detected the user speaking over a reply.
       // The on-device AEC keeps the assistant's own voice out of the mic, so a
-      // speech_started while a reply is playing is the user talking. Cancel the
-      // server's reply and flush the queued playback (the server can't unsend
-      // audio it already streamed to us, so the client must drain its buffer).
+      // speech_started while a reply is playing is the user talking. The server
+      // stops generating on its own (interrupt_response, set in the session);
+      // the client just flushes the queued playback and drops the cancelled
+      // reply's tail (the server can't unsend audio it already streamed to us).
+      // We deliberately do NOT send response.cancel: the server has usually
+      // already cancelled the response by now, so it would race and error with
+      // "Cancellation failed: no active response found".
       case 'input_audio_buffer.speech_started':
-        final pending = _responseActive || (isPlaybackPending?.call() ?? false);
+        final live = _recentAudio;
+        final pending = live || _playbackPending;
         if (!_barged && pending) {
           // latch `barged` (to drop trailing deltas) only if a reply is still
-          // generating; if it already completed there is no tail to drop and
+          // streaming; if it already finished there is no tail to drop and
           // latching would wrongly mute the next reply. Tag the cancelled reply
           // by id so only its tail is dropped.
-          _barged = _responseActive;
-          _cancelledResponseId = _responseActive ? _currentResponseId : null;
+          _barged = live;
+          _cancelledResponseId = live ? _currentResponseId : null;
           _event('---Interrupted---');
-          _channel?.sink.add(jsonEncode({'type': 'response.cancel'}));
           onInterrupted();
         }
         break;
 
       case 'response.done':
-        _responseActive = false;
+        // (OpenAI sends this; jarvis doesn't - the barge logic no longer
+        // depends on it, but honour it when present.) Clear the barge latch so
+        // the NEXT reply plays; the queued playback was already flushed at
+        // barge-in and the cancelled reply's tail deltas are dropped by id.
         _sawOutputTranscriptDelta = false;
-        // Clear the barge latch so the NEXT reply plays. The queued playback was
-        // already flushed at barge-in and the cancelled reply's tail deltas are
-        // dropped by id, so there is nothing left to flush here.
         _barged = false;
         _cancelledResponseId = null;
         _currentResponseId = null;
+        _lastAudioTime = null;
         onTurnComplete?.call();
         break;
 
@@ -335,6 +545,19 @@ class OpenAiRealtime {
         _log.fine(() => 'Unhandled event: $type');
     }
   }
+
+  /// True if a reply is actively streaming - audio arrived within [_playbackIdle].
+  /// Used instead of a sticky flag so a backend that never sends response.done
+  /// can't leave a reply flagged live forever (which would make every later user
+  /// turn spuriously barge).
+  bool get _recentAudio =>
+      _lastAudioTime != null &&
+      DateTime.now().difference(_lastAudioTime!) < _playbackIdle;
+
+  /// bubble key for a model transcript event: the response id, falling back to
+  /// the item id (either may be absent on backends that don't tag events)
+  String? _outputTurnId(Map<String, dynamic> event) =>
+      event['response_id'] as String? ?? event['item_id'] as String?;
 
   void _event(String msg) {
     _log.info(msg);

--- a/python/packages/brilliant_msg/examples/lua/openai_realtime_frame_app.lua
+++ b/python/packages/brilliant_msg/examples/lua/openai_realtime_frame_app.lua
@@ -18,7 +18,9 @@ AUDIO_DATA_FINAL_MSG = 0x06
 local parsers = {}
 parsers[CLEAR_MSG] = code.parse_code
 parsers[TEXT_MSG] = plain_text.parse_plain_text
-parsers[START_LISTENING_MSG] = code.parse_code
+-- START_LISTENING carries three named config bytes (see its handler), not a
+-- single code, so it takes the raw payload straight through.
+parsers[START_LISTENING_MSG] = function(raw) return raw end
 parsers[STOP_LISTENING_MSG] = code.parse_code
 parsers[START_PLAYBACK_MSG] = code.parse_code
 parsers[STOP_PLAYBACK_MSG] = code.parse_code
@@ -62,14 +64,23 @@ handlers[CLEAR_MSG] = function(parsed_data)
 	clear_display()
 end
 
-handlers[START_LISTENING_MSG] = function(parsed_data)
-	-- Halo-only: stream LC3-encoded microphone audio at 16kHz mono
-	-- value carries the mic gain offset by +10 (0..20 -> gain -10..10)
-	local gain = 0
-	if parsed_data.value ~= nil and parsed_data.value >= 0 and parsed_data.value <= 20 then
-		gain = parsed_data.value - 10
+handlers[START_LISTENING_MSG] = function(raw)
+	-- Halo-only: stream LC3-encoded microphone audio at 16kHz mono.
+	-- Payload is three named bytes (see openai_realtime.py mic_start_payload):
+	--   [1] gain code 0..20  -> mic gain -10..10  ([1] - 10)
+	--   [2] aec   0/1         -> echo cancellation on/off
+	--   [3] voice 0/1         -> voice-band mode on/off (band-pass the AEC
+	--                            output, so the server VAD only hears near-end)
+	local gain, aec_on, voice = 0, true, false
+	if raw ~= nil and #raw >= 3 then
+		gain = string.byte(raw, 1) - 10
+		aec_on = string.byte(raw, 2) ~= 0
+		voice = string.byte(raw, 3) ~= 0
 	end
+	if gain < -10 then gain = -10 elseif gain > 10 then gain = 10 end
 	pcall(frame.microphone.start, {encoder='lc3', sample_rate=16000, bitrate=32000, channels=1, gain=gain})
+	pcall(frame.microphone.aec, aec_on)
+	pcall(frame.microphone.voice, voice)
 	listening = true
 end
 

--- a/python/packages/brilliant_msg/examples/openai_realtime.py
+++ b/python/packages/brilliant_msg/examples/openai_realtime.py
@@ -11,10 +11,16 @@ API. liblc3 (via the ``lc3py`` package) does the conversion inside the codec:
 the Halo LC3 streams stay at 16 kHz while the decoder outputs / encoder accepts
 24 kHz PCM. So there's no separate resampler, and no rate to configure.
 
-Half-duplex: the mic is muted while the assistant is speaking, because the
-bone-conduction speaker bleeds into the mic and there is no echo cancellation
-yet. This keeps the session simple and linear - the server's voice-activity
-detection starts a reply when you stop talking; talk again after it finishes.
+Full-duplex: the mic streams continuously, even while the assistant is
+speaking, so you can talk over a reply to interrupt it ("barge-in"). This
+relies on the Halo firmware's on-device acoustic echo canceller to strip the
+bone-conduction speaker's bleed out of the mic feed - otherwise the server's
+voice-activity detector would hear the assistant's own voice and the reply
+would interrupt itself. The server VAD starts a reply when you stop talking
+and flags a barge-in when you start; on a barge-in we drop the rest of the
+current reply and flush the queued playback so the assistant stops promptly
+(the server can't cancel audio it already finished streaming to us, so the
+client must drain its own buffer).
 
 Usage:
     export OPENAI_API_KEY=sk-...
@@ -64,6 +70,15 @@ SPEAKER_VOLUME = 100  # the Halo speaker is quiet, so run it at full volume
 HALO_CHARS_PER_LINE = 21
 
 
+def mic_start_payload(gain: int, aec: bool, voice: bool) -> bytes:
+    """START_LISTENING payload: three named bytes, one field each, decoded by
+    the frame app's START_LISTENING handler:
+        [0] gain code 0..20 (10 = 0 dB)   [1] aec 0/1   [2] voice 0/1
+    This maps 1:1 onto frame.microphone.start{gain=}, .aec(bool), .voice(bool).
+    """
+    return bytes([max(0, min(20, gain)), 1 if aec else 0, 1 if voice else 0])
+
+
 def wrap_for_halo(text: str, max_lines: int = 4) -> str:
     """Word-wrap text for the Halo display and keep the last `max_lines` lines."""
     lines: list[str] = []
@@ -99,7 +114,12 @@ def session_update(voice: str, instructions: str) -> dict:
                 "input": {
                     "format": {"type": "audio/pcm", "rate": SERVER_RATE},
                     "transcription": {"model": "whisper-1"},
-                    "turn_detection": {"type": "server_vad"},
+                    # interrupt_response lets the server stop generating when it
+                    # detects a barge-in; the client still flushes its own queued
+                    # playback (below), since the server can't cancel audio it has
+                    # already streamed to us.
+                    "turn_detection": {"type": "server_vad",
+                                       "interrupt_response": True},
                 },
                 "output": {
                     "format": {"type": "audio/pcm", "rate": SERVER_RATE},
@@ -131,9 +151,15 @@ class Session:
         self._assistant_text = ""  # accumulates the current reply transcript
         self._saw_transcript_delta = False  # did this turn stream transcript deltas?
 
-    def _speaking(self) -> bool:
-        """Half-duplex gate: True while a reply is generating or still playing out."""
-        return self.response_active or not self.speaker_queue.empty()
+        # barge-in state
+        self.barged = False  # client has cancelled the current reply; drop its tail
+        self.current_response_id = None  # id of the reply currently streaming audio
+        self.cancelled_response_id = None  # id cancelled on barge; drop only its tail
+
+    def _playback_pending(self) -> bool:
+        """True while a reply is generating or still queued/playing out."""
+        return (self.response_active or not self.speaker_queue.empty()
+                or bool(self._spk_pcm_buf))
 
     # --- Halo mic -> OpenAI -----------------------------------------------
     async def pump_mic(self, mic_queue: asyncio.Queue):
@@ -149,9 +175,11 @@ class Session:
                 del self._mic_lc3_buf[:LC3_FRAME_BYTES]
                 pcm += self.decoder.decode(frame_bytes, bit_depth=16)
 
-            # drop mic audio while the assistant is speaking (no echo cancellation)
-            if not pcm or self._speaking():
+            if not pcm:
                 continue
+
+            # full duplex: the mic streams even while the assistant speaks; the
+            # firmware AEC strips the speaker bleed so this is (mostly) near-end
             await self.ws.send(json.dumps({
                 "type": "input_audio_buffer.append",
                 "audio": base64.b64encode(bytes(pcm)).decode("ascii"),
@@ -178,6 +206,32 @@ class Session:
             # pace slightly faster than realtime (each frame is 10 ms of audio)
             await asyncio.sleep(len(frames) * 0.009)
 
+    def _flush_playback(self) -> int:
+        """Drop all queued/partial playback; return the frame count dropped."""
+        dropped = 0
+        while not self.speaker_queue.empty():
+            self.speaker_queue.get_nowait()
+            dropped += 1
+        self._spk_pcm_buf.clear()
+        return dropped
+
+    async def _client_barge_in(self):
+        """The server VAD flagged near-end speech over a live reply: stop it now.
+        Flushing the queue is what actually stops the echo - the server can't
+        cancel audio it already sent us, and up to several seconds of it may be
+        buffered here. We also latch `barged` (to drop the reply's trailing
+        deltas) only if it is still generating; if it already completed there is
+        no tail to drop and latching would wrongly mute the next reply. Tag the
+        cancelled reply by id so only its tail is dropped."""
+        self.barged = self.response_active
+        self.cancelled_response_id = self.current_response_id if self.response_active else None
+        dropped = self._flush_playback()
+        try:
+            await self.ws.send(json.dumps({"type": "response.cancel"}))
+        except Exception:
+            pass
+        print(f"\n[barge-in] flushed {dropped} queued frames", flush=True)
+
     # --- OpenAI event stream ----------------------------------------------
     async def receive(self):
         async for message in self.ws:
@@ -186,9 +240,29 @@ class Session:
 
             if etype == "response.created":
                 self.response_active = True
+                self.barged = False
+                self.cancelled_response_id = None
+                self.current_response_id = (event.get("response") or {}).get("id")
                 self._assistant_text = ""
                 self._saw_transcript_delta = False
             elif etype == "response.output_audio.delta":
+                rid = event.get("response_id")
+                if self.barged:
+                    # drop ONLY the cancelled reply's tail; a delta from a new
+                    # reply (or any delta when the backend omits ids) means the
+                    # barge is over - so the latch can never get stuck silencing
+                    # every future reply if response.done/created never arrive
+                    if rid is not None and rid == self.cancelled_response_id:
+                        continue
+                    self.barged = False
+                    self.cancelled_response_id = None
+                # Track response_active off the audio stream, not just
+                # response.created: some backends (e.g. jarvis in server-VAD mode)
+                # never emit response.created for auto-created replies, so keying
+                # the barge logic on it alone would silently break. A delta means
+                # a reply is live; response.done ends it.
+                self.current_response_id = rid
+                self.response_active = True
                 self._enqueue_playback(base64.b64decode(event["delta"]))
             elif etype == "response.output_audio_transcript.delta":
                 delta = event.get("delta", "")
@@ -199,22 +273,35 @@ class Session:
             elif etype == "conversation.item.input_audio_transcription.completed":
                 transcript = (event.get("transcript") or "").strip()
                 if transcript:
-                    print(f"\nYou: {transcript}")
+                    print(f"\nYou: {transcript}", flush=True)
             elif etype == "response.output_audio_transcript.done":
                 # some backends (e.g. huggingface/speech-to-speech) send the
                 # assistant transcript only here, not as deltas - render it then
                 if not self._saw_transcript_delta:
                     full = (event.get("transcript") or "").strip()
                     if full:
-                        print(f"Assistant: {full}")
+                        print(f"Assistant: {full}", flush=True)
                         await self._show(wrap_for_halo(full))
                 else:
                     print()  # newline after the streamed transcript
+            elif etype == "input_audio_buffer.speech_started":
+                # The server VAD heard near-end speech. If a reply is playing,
+                # barge in: the on-device AEC keeps the assistant's own voice
+                # out of the mic, so a speech_started here is the user talking.
+                if not self.barged and self._playback_pending():
+                    await self._client_barge_in()
             elif etype == "response.done":
                 self.response_active = False
+                # Clear the barge latch so the NEXT reply plays. The queued
+                # playback was already flushed at barge-in and the cancelled
+                # reply's tail deltas are dropped by id, so there is nothing
+                # left to flush here.
+                self.barged = False
+                self.cancelled_response_id = None
+                self.current_response_id = None
             elif etype == "error":
                 err = event.get("error", {})
-                print(f"\n[error] {err.get('message', err)}")
+                print(f"\n[error] {err.get('message', err)}", flush=True)
 
     async def _show(self, text: str):
         try:
@@ -233,6 +320,14 @@ def parse_args() -> argparse.Namespace:
                    help="API key; defaults to env OPENAI_API_KEY. Pass '' for a "
                         "local backend with no auth")
     p.add_argument("--voice", default="alloy", help="assistant voice")
+    p.add_argument("--name", default=None,
+                   help="Halo device local name to connect to (e.g. \"Halo 08\"); "
+                        "defaults to the first Halo found")
+    p.add_argument("--no-voice-mode", dest="voice_mode", action="store_false",
+                   help="disable the on-device AEC voice mode (band-pass) on the mic")
+    p.add_argument("--aec-off", dest="aec", action="store_false",
+                   help="disable the on-device AEC entirely (control baseline)")
+    p.set_defaults(voice_mode=True, aec=True)
     p.add_argument("--instructions",
                    default="You are a helpful assistant speaking to the user "
                            "through their smart glasses. Be natural, direct and "
@@ -248,7 +343,7 @@ async def main():
     frame = BrilliantMsg()
     started_audio = False
     try:
-        await frame.connect()
+        await frame.connect(name=args.name)
         if frame.type != BrilliantDeviceType.HALO:
             print("This example requires a Halo (LC3 audio in both directions)")
             return
@@ -263,7 +358,7 @@ async def main():
         await frame.start_frame_app()
 
         headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
-        print(f"Connecting to {args.url} ...")
+        print(f"Connecting to {args.url} ...", flush=True)
         async with connect(args.url, additional_headers=headers, max_size=None) as ws:
             await ws.send(json.dumps(session_update(args.voice, args.instructions)))
 
@@ -273,11 +368,16 @@ async def main():
             rx_audio = RxAudio(streaming=True)
             mic_queue = await rx_audio.attach(frame)
 
+            print(f"mic: gain={MIC_GAIN_VALUE - 10} aec={'on' if args.aec else 'off'} "
+                  f"voice_mode={'on' if args.voice_mode else 'off'}", flush=True)
+
             await frame.send_message(START_PLAYBACK_MSG, TxCode(SPEAKER_VOLUME).pack())
-            await frame.send_message(START_LISTENING_MSG, TxCode(MIC_GAIN_VALUE).pack())
+            await frame.send_message(
+                START_LISTENING_MSG,
+                mic_start_payload(MIC_GAIN_VALUE, aec=args.aec, voice=args.voice_mode))
             started_audio = True
             await session._show("Listening...")
-            print("Session started - speak to the Halo. Ctrl-C to quit.\n")
+            print("Session started - speak to the Halo. Ctrl-C to quit.\n", flush=True)
 
             # run until Ctrl-C or a task ends (e.g. the websocket closes)
             stop = asyncio.Event()
@@ -299,7 +399,7 @@ async def main():
             for t in done:
                 exc = t.exception()
                 if exc and not isinstance(exc, asyncio.CancelledError):
-                    print(f"\n[stopped] {exc!r}")
+                    print(f"\n[stopped] {exc!r}", flush=True)
 
             rx_audio.detach(frame)
     except KeyboardInterrupt:

--- a/python/packages/brilliant_msg/examples/openai_realtime.py
+++ b/python/packages/brilliant_msg/examples/openai_realtime.py
@@ -11,16 +11,18 @@ API. liblc3 (via the ``lc3py`` package) does the conversion inside the codec:
 the Halo LC3 streams stay at 16 kHz while the decoder outputs / encoder accepts
 24 kHz PCM. So there's no separate resampler, and no rate to configure.
 
-Full-duplex: the mic streams continuously, even while the assistant is
-speaking, so you can talk over a reply to interrupt it ("barge-in"). This
-relies on the Halo firmware's on-device acoustic echo canceller to strip the
-bone-conduction speaker's bleed out of the mic feed - otherwise the server's
-voice-activity detector would hear the assistant's own voice and the reply
-would interrupt itself. The server VAD starts a reply when you stop talking
-and flags a barge-in when you start; on a barge-in we drop the rest of the
-current reply and flush the queued playback so the assistant stops promptly
-(the server can't cancel audio it already finished streaming to us, so the
-client must drain its own buffer).
+Full-duplex barge-in: you can talk over a reply to interrupt it. This leans on
+the Halo firmware's on-device acoustic echo canceller to strip the bone-conduction
+speaker's bleed out of the mic - otherwise the server's voice-activity detector
+would hear the assistant's own voice and interrupt itself. The AEC alone is enough
+for a forgiving VAD (e.g. a local Silero server), but OpenAI's server VAD is
+sensitive enough to trip on the post-AEC echo residual - transcribing it as a
+phantom user turn and answering it, a self-interruption spiral. So during playback
+the mic is held closed to the server by a client-side RMS gate and only opened once
+the near-end level confirms you are really talking (see BARGE_RMS; --barge-rms 0
+disables it for full duplex). On a barge-in we also drop the rest of the current
+reply and flush the queued playback so the assistant stops promptly (the server
+can't cancel audio it already finished streaming to us, so the client drains it).
 
 Usage:
     export OPENAI_API_KEY=sk-...
@@ -39,8 +41,11 @@ import base64
 import json
 import os
 import signal
+import time
+from collections import deque
 
 import lc3
+import numpy as np
 from websockets.asyncio.client import connect
 
 from brilliant_ble import BrilliantDeviceType
@@ -65,6 +70,34 @@ SERVER_RATE = 24000  # PCM rate over the wire, per the official OpenAI Realtime 
 PCM_FRAME_BYTES = SERVER_RATE // 100 * 2  # 10 ms of 24 kHz PCM16 = 480 bytes
 MIC_GAIN_VALUE = 10  # device maps 0..20 -> gain -10..10; 10 -> gain 0
 SPEAKER_VOLUME = 100  # the Halo speaker is quiet, so run it at full volume
+
+# After this long with no new reply audio (and nothing queued), treat playback
+# as finished. Used INSTEAD of response.done to decide when a reply is "playing"
+# for barge-in, because some backends (e.g. jarvis in server-VAD mode) never
+# send response.done - keying on it would leave a reply flagged active forever,
+# so every later user turn would spuriously barge (flushing 0 frames).
+PLAYBACK_IDLE_S = 1.0
+
+# How long after the device finishes playing (per the playback clock) a reply still
+# counts as playing, covering on-device / in-flight buffer latency. The client sends
+# audio faster than real time but the device plays it out in real time, so the
+# barge-in gate must stay armed for the whole physical playout - not just while the
+# client queue is non-empty - or the reply's tail leaks its echo past the gate.
+PLAYBACK_TAIL_S = 0.6
+
+# RMS barge-in gate. A sensitive server VAD (notably OpenAI's, which also runs
+# transcription) can trip on the assistant's own post-AEC echo residual, transcribe
+# it as a phantom user turn and answer it - a self-interruption loop. The gate is
+# applied ONLY while a reply is playing: when the assistant is silent the mic streams
+# straight through (normal turn-taking needs no raised voice); while it plays, the
+# mic is held closed to the server until the near-end (DC-removed / AC) RMS confirms
+# the wearer is talking OVER it. The bar must sit ABOVE the echo peak, not just the
+# quiet floor - too low and echo both opens the gate AND keeps it from re-closing.
+# Set --barge-rms 0 to disable the gate (full duplex; fine for a backend that does
+# not trip on the residual). See tests/aec/README.md "server-VAD-alone A/B".
+BARGE_RMS = 400.0          # AC-RMS a mic read must clear to barge OVER a live reply
+BARGE_CONFIRM_FRAMES = 3   # consecutive above-threshold reads to open the mic gate
+BARGE_HANGOVER_MS = 400.0  # sub-threshold audio after which the open gate re-closes
 
 # glasses display: monospace 9pt, ~21 chars fit across the 256px width
 HALO_CHARS_PER_LINE = 21
@@ -102,8 +135,25 @@ def wrap_for_halo(text: str, max_lines: int = 4) -> str:
     return "\n".join(lines[-max_lines:])
 
 
-def session_update(voice: str, instructions: str) -> dict:
+def session_update(voice: str, instructions: str,
+                   vad_threshold: float = 0.6,
+                   vad_silence_ms: int = None) -> dict:
     """The OpenAI Realtime GA session.update message (24 kHz PCM)."""
+    turn_detection = {"type": "server_vad",
+                      # interrupt_response lets the server stop generating when it
+                      # detects a barge-in; the client still flushes its own queued
+                      # playback (below), since the server can't cancel audio it has
+                      # already streamed to us.
+                      "interrupt_response": True,
+                      # VAD activation threshold (default 0.5). Raising it makes the
+                      # assistant's own residual echo less likely to trip the VAD -
+                      # but the echo IS speech-shaped, so this scores it high and a
+                      # higher threshold also costs real barges: the client RMS gate
+                      # (near-end ENERGY, --barge-rms) is the sharper separator. Kept
+                      # exposed (--vad-threshold) to tune or stack with the gate.
+                      "threshold": vad_threshold}
+    if vad_silence_ms is not None:
+        turn_detection["silence_duration_ms"] = vad_silence_ms
     return {
         "type": "session.update",
         "session": {
@@ -114,12 +164,7 @@ def session_update(voice: str, instructions: str) -> dict:
                 "input": {
                     "format": {"type": "audio/pcm", "rate": SERVER_RATE},
                     "transcription": {"model": "whisper-1"},
-                    # interrupt_response lets the server stop generating when it
-                    # detects a barge-in; the client still flushes its own queued
-                    # playback (below), since the server can't cancel audio it has
-                    # already streamed to us.
-                    "turn_detection": {"type": "server_vad",
-                                       "interrupt_response": True},
+                    "turn_detection": turn_detection,
                 },
                 "output": {
                     "format": {"type": "audio/pcm", "rate": SERVER_RATE},
@@ -133,10 +178,25 @@ def session_update(voice: str, instructions: str) -> dict:
 class Session:
     """Bridges the Halo audio streams and an OpenAI Realtime websocket."""
 
-    def __init__(self, frame: BrilliantMsg, ws, frames_per_write: int):
+    def __init__(self, frame: BrilliantMsg, ws, frames_per_write: int,
+                 barge_rms: float = BARGE_RMS,
+                 barge_confirm_frames: int = BARGE_CONFIRM_FRAMES,
+                 barge_hangover_ms: float = BARGE_HANGOVER_MS):
         self.frame = frame
         self.ws = ws
         self.frames_per_write = frames_per_write
+
+        # RMS barge-in gate (see BARGE_RMS): near-end confirmation before the mic
+        # is opened to the server during playback, so the assistant's echo can't
+        # be transcribed as a phantom turn and spiral. barge_rms<=0 disables it.
+        self.barge_rms = barge_rms
+        self.barge_confirm_frames = max(1, barge_confirm_frames)
+        self.barge_hangover_ms = barge_hangover_ms
+        self.gate_open = False        # currently forwarding near-end during playback
+        self.gate_hot = 0             # consecutive above-threshold reads (to open)
+        self.gate_peak = 0.0          # loudest read while arming (logged on open)
+        self.gate_quiet_ms = 0.0      # accumulated sub-threshold audio (to close)
+        self._preroll: deque = deque(maxlen=self.barge_confirm_frames)  # onset back-fill
 
         # liblc3 does the resampling inside the codec: coded 16 kHz Halo LC3 <->
         # 24 kHz PCM over the wire. The decoder upsamples the mic to 24 kHz; the
@@ -147,7 +207,8 @@ class Session:
         self.speaker_queue: asyncio.Queue = asyncio.Queue()  # LC3 frames to play out
         self._mic_lc3_buf = bytearray()  # unaligned LC3 bytes from the mic
         self._spk_pcm_buf = bytearray()  # server PCM awaiting frame alignment
-        self.response_active = False  # a reply is being generated
+        self.last_audio_time = None  # monotonic time of the last reply audio delta
+        self.play_until = 0.0  # monotonic time the device finishes playing what we sent
         self._assistant_text = ""  # accumulates the current reply transcript
         self._saw_transcript_delta = False  # did this turn stream transcript deltas?
 
@@ -156,10 +217,30 @@ class Session:
         self.current_response_id = None  # id of the reply currently streaming audio
         self.cancelled_response_id = None  # id cancelled on barge; drop only its tail
 
+    def _recent_audio(self) -> bool:
+        """True if a reply is actively streaming - audio arrived within the last
+        PLAYBACK_IDLE_S. Used instead of a sticky response_active flag so that a
+        backend which never sends response.done can't leave a reply flagged live
+        forever (which would make every later user turn spuriously barge)."""
+        return (self.last_audio_time is not None
+                and time.monotonic() - self.last_audio_time < PLAYBACK_IDLE_S)
+
     def _playback_pending(self) -> bool:
-        """True while a reply is generating or still queued/playing out."""
-        return (self.response_active or not self.speaker_queue.empty()
-                or bool(self._spk_pcm_buf))
+        """True while the DEVICE is still playing a reply out (not merely while the
+        client still holds audio).
+
+        Keys on the playback clock (see PLAYBACK_TAIL_S), not on when audio was
+        received: the client drains its queue seconds before the device finishes
+        the physical playout, so using the queue/recent-audio as "done" reopens the
+        mic - gate off - mid-playout and leaks the reply's tail to the server. The
+        queue check stays as a floor for the instant between enqueue and the first
+        send that advances the clock.
+
+        Deliberately does NOT consider `_spk_pcm_buf`: it holds the trailing sub-
+        frame (<10 ms) that never filled a whole 480-byte block and is never
+        played, so treating it as "playing" would gate every later user turn."""
+        return (not self.speaker_queue.empty()
+                or time.monotonic() < self.play_until + PLAYBACK_TAIL_S)
 
     # --- Halo mic -> OpenAI -----------------------------------------------
     async def pump_mic(self, mic_queue: asyncio.Queue):
@@ -178,12 +259,75 @@ class Session:
             if not pcm:
                 continue
 
-            # full duplex: the mic streams even while the assistant speaks; the
-            # firmware AEC strips the speaker bleed so this is (mostly) near-end
-            await self.ws.send(json.dumps({
-                "type": "input_audio_buffer.append",
-                "audio": base64.b64encode(bytes(pcm)).decode("ascii"),
-            }))
+            await self._forward_mic(bytes(pcm))
+
+    async def _send_mic(self, pcm: bytes):
+        await self.ws.send(json.dumps({
+            "type": "input_audio_buffer.append",
+            "audio": base64.b64encode(pcm).decode("ascii"),
+        }))
+
+    async def _forward_mic(self, pcm: bytes):
+        """Forward a mic block to the server, RMS-gated during playback.
+
+        With the gate disabled (--barge-rms 0) or when no reply is playing, the
+        mic streams straight through - normal full-duplex listening / turn-taking.
+        While a reply IS playing, the mic is held closed and only opened once the
+        near-end AC-RMS clears the gate for `barge_confirm_frames` consecutive
+        reads, so the server never hears (and so never transcribes and answers)
+        the assistant's own echo. On open we back-fill the buffered onset so the
+        barge's first word isn't clipped; the gate then stays open through the
+        utterance, re-closing after BARGE_HANGOVER_MS of near-silence."""
+        if self.barge_rms <= 0 or not self._playback_pending():
+            # gate disabled, or nothing playing: stream through; reset gate state
+            self.gate_open = False
+            self.gate_hot = 0
+            self.gate_quiet_ms = 0.0
+            self._preroll.clear()
+            await self._send_mic(pcm)
+            return
+
+        samples = np.frombuffer(pcm, dtype=np.int16)
+        # DC-removed (AC) RMS: echo residual is low-energy post-AEC even though it
+        # is speech-shaped, so measure energy (std), not level (see BARGE_RMS).
+        rms = float(np.std(samples.astype(np.float64))) if samples.size > 1 else 0.0
+        dur_ms = 1000.0 * samples.size / SERVER_RATE
+
+        if self.gate_open:
+            # stay open through the utterance; close after a beat of near-silence
+            if rms < self.barge_rms:
+                self.gate_quiet_ms += dur_ms
+            else:
+                self.gate_quiet_ms = 0.0
+            if self.gate_quiet_ms < self.barge_hangover_ms:
+                await self._send_mic(pcm)
+                return
+            self.gate_open = False  # fell quiet: re-close and re-arm below
+            self.gate_hot = 0
+            self.gate_quiet_ms = 0.0
+
+        # gate closed: buffer the onset and count consecutive above-threshold reads
+        self._preroll.append(pcm)
+        if rms >= self.barge_rms:
+            self.gate_hot += 1
+            self.gate_peak = max(self.gate_peak, rms)
+        else:
+            self.gate_hot = 0
+            self.gate_peak = 0.0
+        if self.gate_hot >= self.barge_confirm_frames:
+            # confirmed near-end: open, back-fill the buffered onset, then stream.
+            # Log the RMS that opened it: an open near the threshold (rather than
+            # well above it) is echo leaking through - raise --barge-rms if so.
+            print(f"[gate open] near-end rms={self.gate_peak:.0f}", flush=True)
+            self.gate_open = True
+            self.gate_quiet_ms = 0.0
+            self.gate_hot = 0
+            self.gate_peak = 0.0
+            for buffered in self._preroll:
+                await self._send_mic(buffered)
+            self._preroll.clear()
+        # else: closed + unconfirmed -> drop this block (echo-only); the server
+        # never sees it, so it can't spiral
 
     # --- OpenAI -> Halo speaker -------------------------------------------
     def _enqueue_playback(self, pcm: bytes):
@@ -203,6 +347,10 @@ class Session:
                 except asyncio.QueueEmpty:
                     break
             await self.frame.send_audio(b"".join(frames), await_bt_response=False)
+            # advance the playback clock: the device plays these frames out in real
+            # time (10 ms each) from wherever it's currently up to, so the gate stays
+            # armed for the full physical playout (see PLAYBACK_TAIL_S)
+            self.play_until = max(self.play_until, time.monotonic()) + len(frames) * 0.010
             # pace slightly faster than realtime (each frame is 10 ms of audio)
             await asyncio.sleep(len(frames) * 0.009)
 
@@ -216,20 +364,23 @@ class Session:
         return dropped
 
     async def _client_barge_in(self):
-        """The server VAD flagged near-end speech over a live reply: stop it now.
-        Flushing the queue is what actually stops the echo - the server can't
-        cancel audio it already sent us, and up to several seconds of it may be
-        buffered here. We also latch `barged` (to drop the reply's trailing
-        deltas) only if it is still generating; if it already completed there is
-        no tail to drop and latching would wrongly mute the next reply. Tag the
-        cancelled reply by id so only its tail is dropped."""
-        self.barged = self.response_active
-        self.cancelled_response_id = self.current_response_id if self.response_active else None
+        """The server VAD flagged near-end speech over a live reply. The server
+        stops generating on its own (interrupt_response, set in the session), so
+        here the client only flushes the queued playback - that is what actually
+        stops the echo, since the server can't unsend audio it already streamed
+        to us and up to several seconds of it may be buffered here. We latch
+        `barged` (to drop the reply's trailing deltas) only if it is still
+        generating; if it already completed there is no tail to drop and latching
+        would wrongly mute the next reply. Tag the cancelled reply by id so only
+        its tail is dropped.
+
+        We deliberately do NOT send response.cancel: with interrupt_response the
+        server has usually already cancelled the response by now, so it would
+        race and error with "Cancellation failed: no active response found"."""
+        live = self._recent_audio()
+        self.barged = live
+        self.cancelled_response_id = self.current_response_id if live else None
         dropped = self._flush_playback()
-        try:
-            await self.ws.send(json.dumps({"type": "response.cancel"}))
-        except Exception:
-            pass
         print(f"\n[barge-in] flushed {dropped} queued frames", flush=True)
 
     # --- OpenAI event stream ----------------------------------------------
@@ -239,7 +390,6 @@ class Session:
             etype = event.get("type")
 
             if etype == "response.created":
-                self.response_active = True
                 self.barged = False
                 self.cancelled_response_id = None
                 self.current_response_id = (event.get("response") or {}).get("id")
@@ -256,13 +406,12 @@ class Session:
                         continue
                     self.barged = False
                     self.cancelled_response_id = None
-                # Track response_active off the audio stream, not just
-                # response.created: some backends (e.g. jarvis in server-VAD mode)
-                # never emit response.created for auto-created replies, so keying
-                # the barge logic on it alone would silently break. A delta means
-                # a reply is live; response.done ends it.
+                # Mark the reply live off the audio stream (see _recent_audio):
+                # some backends (e.g. jarvis in server-VAD mode) emit neither
+                # response.created nor response.done, so a fresh audio delta is
+                # the only reliable "a reply is playing" signal.
                 self.current_response_id = rid
-                self.response_active = True
+                self.last_audio_time = time.monotonic()
                 self._enqueue_playback(base64.b64decode(event["delta"]))
             elif etype == "response.output_audio_transcript.delta":
                 delta = event.get("delta", "")
@@ -291,14 +440,15 @@ class Session:
                 if not self.barged and self._playback_pending():
                     await self._client_barge_in()
             elif etype == "response.done":
-                self.response_active = False
-                # Clear the barge latch so the NEXT reply plays. The queued
-                # playback was already flushed at barge-in and the cancelled
-                # reply's tail deltas are dropped by id, so there is nothing
-                # left to flush here.
+                # (OpenAI sends this; jarvis doesn't - the barge logic no longer
+                # depends on it, but honour it when present.) Clear the barge
+                # latch so the NEXT reply plays; the queued playback was already
+                # flushed at barge-in and the cancelled reply's tail deltas are
+                # dropped by id, so there is nothing left to flush here.
                 self.barged = False
                 self.cancelled_response_id = None
                 self.current_response_id = None
+                self.last_audio_time = None
             elif etype == "error":
                 err = event.get("error", {})
                 print(f"\n[error] {err.get('message', err)}", flush=True)
@@ -320,8 +470,26 @@ def parse_args() -> argparse.Namespace:
                    help="API key; defaults to env OPENAI_API_KEY. Pass '' for a "
                         "local backend with no auth")
     p.add_argument("--voice", default="alloy", help="assistant voice")
+    p.add_argument("--volume", type=int, default=SPEAKER_VOLUME,
+                   help="Halo speaker volume 1..100 (default 100)")
+    p.add_argument("--barge-rms", type=float, default=BARGE_RMS,
+                   help="RMS barge-in gate: near-end AC-RMS a mic read must clear "
+                        "to open the mic to the server DURING playback, so the "
+                        "assistant's echo can't self-interrupt a sensitive server "
+                        "VAD (default 150). 0 disables the gate (full duplex)")
+    p.add_argument("--barge-confirm-frames", type=int, default=BARGE_CONFIRM_FRAMES,
+                   help="consecutive above-threshold mic reads to open the gate "
+                        "(debounce; higher = fewer false barges, slightly slower onset)")
+    p.add_argument("--barge-hangover-ms", type=float, default=BARGE_HANGOVER_MS,
+                   help="sub-threshold audio after which an open gate re-closes "
+                        "(keep short so it doesn't forward echo into the next reply)")
+    p.add_argument("--vad-threshold", type=float, default=0.6,
+                   help="server VAD activation threshold 0..1 (default 0.6; raise "
+                        "to make echo less likely to trip it - blunter than the gate)")
+    p.add_argument("--vad-silence-ms", type=int, default=None,
+                   help="server VAD silence_duration_ms (turn-end hangover)")
     p.add_argument("--name", default=None,
-                   help="Halo device local name to connect to (e.g. \"Halo 08\"); "
+                   help="Halo device local name to connect to (e.g. \"Halo XX\"); "
                         "defaults to the first Halo found")
     p.add_argument("--no-voice-mode", dest="voice_mode", action="store_false",
                    help="disable the on-device AEC voice mode (band-pass) on the mic")
@@ -360,18 +528,28 @@ async def main():
         headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
         print(f"Connecting to {args.url} ...", flush=True)
         async with connect(args.url, additional_headers=headers, max_size=None) as ws:
-            await ws.send(json.dumps(session_update(args.voice, args.instructions)))
+            await ws.send(json.dumps(session_update(
+                args.voice, args.instructions,
+                vad_threshold=args.vad_threshold,
+                vad_silence_ms=args.vad_silence_ms)))
 
             frames_per_write = max(1, frame.max_lua_payload() // LC3_FRAME_BYTES)
-            session = Session(frame, ws, frames_per_write)
+            session = Session(frame, ws, frames_per_write,
+                              barge_rms=args.barge_rms,
+                              barge_confirm_frames=args.barge_confirm_frames,
+                              barge_hangover_ms=args.barge_hangover_ms)
 
             rx_audio = RxAudio(streaming=True)
             mic_queue = await rx_audio.attach(frame)
 
+            gate = ("off" if args.barge_rms <= 0
+                    else f"rms>={args.barge_rms:.0f}x{args.barge_confirm_frames}")
             print(f"mic: gain={MIC_GAIN_VALUE - 10} aec={'on' if args.aec else 'off'} "
-                  f"voice_mode={'on' if args.voice_mode else 'off'}", flush=True)
+                  f"voice_mode={'on' if args.voice_mode else 'off'} "
+                  f"volume={args.volume} barge_gate={gate} "
+                  f"vad_threshold={args.vad_threshold}", flush=True)
 
-            await frame.send_message(START_PLAYBACK_MSG, TxCode(SPEAKER_VOLUME).pack())
+            await frame.send_message(START_PLAYBACK_MSG, TxCode(args.volume).pack())
             await frame.send_message(
                 START_LISTENING_MSG,
                 mic_start_payload(MIC_GAIN_VALUE, aec=args.aec, voice=args.voice_mode))


### PR DESCRIPTION
Full-duplex **realtime_openai** example (Python + Flutter) for Halo: talk to
the OpenAI Realtime API (or any OpenAI-Realtime GA-compatible backend, e.g. a
local huggingface/speech-to-speech server) and barge in over a reply, leaning
on the on-device AEC to keep the assistant's own voice out of the mic.

Branches off the `brilliant_msg connect(name=...)` change already on main
(#27), which is why that commit isn't in this PR.

## Commits

- **python: full-duplex realtime_openai with on-device AEC barge-in** — the
  Python sample: Halo mic (LC3 16kHz) ⇄ OpenAI Realtime (24kHz PCM), reply on
  the Halo speaker, transcript on the glasses. Full-duplex barge-in via server
  VAD + `interrupt_response`, client flush of queued playback.
- **flutter: full-duplex realtime_openai with on-device AEC barge-in** — the
  Flutter example mirroring it (`OpenAiRealtime` websocket client + audio
  pipeline).
- **python: RMS barge-in gate + playback clock for realtime_openai** — stops
  the self-interruption spiral against OpenAI's sensitive server VAD (it
  transcribes the post-AEC echo residual as a phantom user turn). A playback
  clock keys "is a reply playing?" on physical device playout, and an RMS
  mic-feed gate holds the mic closed to the server until near-end energy
  confirms a real barge.
- **realtime_openai: barge gate + playback clock, and connect/teardown
  robustness** — ports those two fixes to the Flutter example, plus:
  - Bounded websocket handshake + `disconnect()` (`sink.close()`/cancel
    timeouts): closing a sink whose `.ready` rejected (connection refused —
    wrong host/port) never completes, which hung teardown and stranded the app
    in a transient state with no usable controls. Now `cancel()`/`run()` always
    recover to a usable state.
  - Android `INTERNET` permission in the main manifest (release builds don't
    get the debug/profile auto-grant, so couldn't reach the endpoint).
  - iOS ATS exception so this developer example can reach a local non-TLS
    backend (`ws://<host>:8765`).

## Notes

- Investigation + worn A/B data behind the barge gate / playback clock live in
  `halo-firmware`'s `tests/aec/README.md` (server-VAD-alone A/B). Defaults are
  worn-tuned: `bargeRms=400`, `confirmFrames=3`, `hangoverMs=400`,
  `PLAYBACK_TAIL=600ms`; `bargeRms<=0` disables the gate for full duplex
  (jarvis/Silero, which don't spiral).
- Intended to be **squash-merged**.
