### PR TITLE
python: standardize brilliant_ble/brilliant_msg examples and tests (argparse + --name, connection diagnostics, cleanups)

### DIFF
--- a/python/packages/brilliant_ble/README.md
+++ b/python/packages/brilliant_ble/README.md
@@ -22,15 +22,15 @@ async def main():
     frame = BrilliantBle()
 
     try:
-        await frame.connect()
+        name = await frame.connect()
+        print(f"Connected to {name}")
 
         await frame.send_lua("frame.display.text('Hello, World!', 1, 1);frame.display.show();print(nil)", await_print=True)
 
-        await frame.disconnect()
-
     except Exception as e:
-        print(f"Not connected to Device: {e}")
-        return
+        print(f"An error occurred: {e}")
+    finally:
+        await frame.disconnect()
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/python/packages/brilliant_ble/examples/animated_drawing.py
+++ b/python/packages/brilliant_ble/examples/animated_drawing.py
@@ -1,3 +1,4 @@
+"""Halo-only: upload and run a small animated drawing Lua app on the display."""
 import asyncio
 import argparse
 from brilliant_ble import BrilliantBle, BrilliantDeviceType
@@ -37,11 +38,10 @@ async def main():
         print(f"Stopping animation")
         await frame.send_break_signal()
 
-        await frame.disconnect()
-
     except Exception as e:
-        print(f"Not connected to Device: {e}")
-        return
+        print(f"An error occurred: {e}")
+    finally:
+        await frame.disconnect()
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/python/packages/brilliant_ble/examples/animated_drawing.py
+++ b/python/packages/brilliant_ble/examples/animated_drawing.py
@@ -1,11 +1,19 @@
 import asyncio
+import argparse
 from brilliant_ble import BrilliantBle, BrilliantDeviceType
 
 async def main():
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device over BLE and run this example.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     frame = BrilliantBle()
 
     try:
-        await frame.connect()
+        await frame.connect(name=args.name)
 
         if frame.type != BrilliantDeviceType.HALO:
             print("animated_drawing example is Halo-only")

--- a/python/packages/brilliant_ble/examples/animated_drawing.py
+++ b/python/packages/brilliant_ble/examples/animated_drawing.py
@@ -13,7 +13,11 @@ async def main():
     frame = BrilliantBle()
 
     try:
-        await frame.connect(name=args.name)
+        name = await frame.connect(name=args.name)
+        fw = await frame.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+        tag = await frame.send_lua("print(frame.GIT_TAG)", await_print=True)
+        batt = await frame.send_lua("print(frame.battery_level())", await_print=True)
+        print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
         if frame.type != BrilliantDeviceType.HALO:
             print("animated_drawing example is Halo-only")

--- a/python/packages/brilliant_ble/examples/callback_error.py
+++ b/python/packages/brilliant_ble/examples/callback_error.py
@@ -13,7 +13,11 @@ async def main():
     frame = BrilliantBle()
 
     try:
-        await frame.connect(name=args.name)
+        name = await frame.connect(name=args.name)
+        fw = await frame.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+        tag = await frame.send_lua("print(frame.GIT_TAG)", await_print=True)
+        batt = await frame.send_lua("print(frame.battery_level())", await_print=True)
+        print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
         # Optionally attach the python print function to print incoming strings from Frame stdout
         frame._user_print_response_handler = print

--- a/python/packages/brilliant_ble/examples/callback_error.py
+++ b/python/packages/brilliant_ble/examples/callback_error.py
@@ -1,3 +1,4 @@
+"""Show how Lua errors raised inside tap/data callbacks behave, and how to catch them with pcall."""
 import asyncio
 import argparse
 from brilliant_ble import BrilliantBle
@@ -46,11 +47,10 @@ async def main():
         await asyncio.sleep(1)
 
 
-        await frame.disconnect()
-
     except Exception as e:
-        print(f"Not connected to Device: {e}")
-        return
+        print(f"An error occurred: {e}")
+    finally:
+        await frame.disconnect()
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/python/packages/brilliant_ble/examples/callback_error.py
+++ b/python/packages/brilliant_ble/examples/callback_error.py
@@ -1,11 +1,19 @@
 import asyncio
+import argparse
 from brilliant_ble import BrilliantBle
 
 async def main():
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device over BLE and run this example.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     frame = BrilliantBle()
 
     try:
-        await frame.connect()
+        await frame.connect(name=args.name)
 
         # Optionally attach the python print function to print incoming strings from Frame stdout
         frame._user_print_response_handler = print

--- a/python/packages/brilliant_ble/examples/clear_display.py
+++ b/python/packages/brilliant_ble/examples/clear_display.py
@@ -13,10 +13,14 @@ async def main():
     frame = BrilliantBle()
 
     try:
-        await frame.connect(name=args.name)
+        name = await frame.connect(name=args.name)
 
         # stop any application, if running, so we can send lua commands
         await frame.send_break_signal()
+        fw = await frame.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+        tag = await frame.send_lua("print(frame.GIT_TAG)", await_print=True)
+        batt = await frame.send_lua("print(frame.battery_level())", await_print=True)
+        print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
         # initialize Halo display
         await frame.send_lua("frame.display.power_save(false);print(0)", await_print=True)

--- a/python/packages/brilliant_ble/examples/clear_display.py
+++ b/python/packages/brilliant_ble/examples/clear_display.py
@@ -1,11 +1,19 @@
 import asyncio
+import argparse
 from brilliant_ble import BrilliantBle, BrilliantDeviceType
 
 async def main():
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device over BLE and run this example.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     frame = BrilliantBle()
 
     try:
-        await frame.connect()
+        await frame.connect(name=args.name)
 
         # stop any application, if running, so we can send lua commands
         await frame.send_break_signal()

--- a/python/packages/brilliant_ble/examples/clear_display.py
+++ b/python/packages/brilliant_ble/examples/clear_display.py
@@ -1,3 +1,4 @@
+"""Clear the device display (blank the screen) on a Halo or Frame."""
 import asyncio
 import argparse
 from brilliant_ble import BrilliantBle, BrilliantDeviceType
@@ -32,11 +33,10 @@ async def main():
             await frame.send_lua("frame.display.text('', 1, 1);frame.display.show();print(0)", await_print=True)
         print("Display cleared")
 
-        await frame.disconnect()
-
     except Exception as e:
-        print(f"Not connected to Device: {e}")
-        return
+        print(f"An error occurred: {e}")
+    finally:
+        await frame.disconnect()
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/python/packages/brilliant_ble/examples/custom_lua_functions.py
+++ b/python/packages/brilliant_ble/examples/custom_lua_functions.py
@@ -13,7 +13,11 @@ async def main():
     frame = BrilliantBle()
 
     try:
-        await frame.connect(name=args.name)
+        name = await frame.connect(name=args.name)
+        fw = await frame.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+        tag = await frame.send_lua("print(frame.GIT_TAG)", await_print=True)
+        batt = await frame.send_lua("print(frame.battery_level())", await_print=True)
+        print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
         # Optionally attach the python print function to print incoming strings from Frame stdout
         # Note that the upload_file() function will receive a byte from Frame after every packet, and a nil

--- a/python/packages/brilliant_ble/examples/custom_lua_functions.py
+++ b/python/packages/brilliant_ble/examples/custom_lua_functions.py
@@ -1,11 +1,19 @@
 import asyncio
+import argparse
 from brilliant_ble import BrilliantBle
 
 async def main():
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device over BLE and run this example.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     frame = BrilliantBle()
 
     try:
-        await frame.connect()
+        await frame.connect(name=args.name)
 
         # Optionally attach the python print function to print incoming strings from Frame stdout
         # Note that the upload_file() function will receive a byte from Frame after every packet, and a nil

--- a/python/packages/brilliant_ble/examples/custom_lua_functions.py
+++ b/python/packages/brilliant_ble/examples/custom_lua_functions.py
@@ -1,3 +1,4 @@
+"""Upload a Lua file of helper functions to the device and call them over BLE."""
 import asyncio
 import argparse
 from brilliant_ble import BrilliantBle
@@ -44,11 +45,10 @@ async def main():
 
         # For structured message-passing of images, audio etc. between Frame and host, consider the frame-msg package.
 
-        await frame.disconnect()
-
     except Exception as e:
-        print(f"Not connected to Device: {e}")
-        return
+        print(f"An error occurred: {e}")
+    finally:
+        await frame.disconnect()
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/python/packages/brilliant_ble/examples/decompression.py
+++ b/python/packages/brilliant_ble/examples/decompression.py
@@ -1,11 +1,19 @@
 import asyncio
+import argparse
 from brilliant_ble import BrilliantBle
 
 async def main():
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device over BLE and run this example.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     frame = BrilliantBle()
 
     try:
-        await frame.connect()
+        await frame.connect(name=args.name)
 
         lua_script = """
             function decomp_func(data)

--- a/python/packages/brilliant_ble/examples/decompression.py
+++ b/python/packages/brilliant_ble/examples/decompression.py
@@ -1,3 +1,4 @@
+"""Send compressed data to the device and decompress it on-device with frame.compression."""
 import asyncio
 import argparse
 from brilliant_ble import BrilliantBle
@@ -51,11 +52,10 @@ async def main():
 
         await asyncio.sleep(1)
 
-        await frame.disconnect()
-
     except Exception as e:
-        print(f"Not connected to Device: {e}")
-        return
+        print(f"An error occurred: {e}")
+    finally:
+        await frame.disconnect()
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/python/packages/brilliant_ble/examples/decompression.py
+++ b/python/packages/brilliant_ble/examples/decompression.py
@@ -13,7 +13,11 @@ async def main():
     frame = BrilliantBle()
 
     try:
-        await frame.connect(name=args.name)
+        name = await frame.connect(name=args.name)
+        fw = await frame.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+        tag = await frame.send_lua("print(frame.GIT_TAG)", await_print=True)
+        batt = await frame.send_lua("print(frame.battery_level())", await_print=True)
+        print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
         lua_script = """
             function decomp_func(data)

--- a/python/packages/brilliant_ble/examples/echo.py
+++ b/python/packages/brilliant_ble/examples/echo.py
@@ -1,3 +1,4 @@
+"""Send Lua snippets to the device REPL and print the results (a tour of the Lua API over BLE)."""
 import asyncio
 import argparse
 from brilliant_ble import BrilliantBle
@@ -63,11 +64,10 @@ async def main():
         # see custom_lua_functions.py for examples.
         # For structured message-passing of images, audio etc. between Frame and host, consider the frame-msg package.
 
-        await frame.disconnect()
-
     except Exception as e:
-        print(f"Not connected to Device: {e}")
-        return
+        print(f"An error occurred: {e}")
+    finally:
+        await frame.disconnect()
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/python/packages/brilliant_ble/examples/echo.py
+++ b/python/packages/brilliant_ble/examples/echo.py
@@ -13,7 +13,11 @@ async def main():
     frame = BrilliantBle()
 
     try:
-        await frame.connect(name=args.name)
+        name = await frame.connect(name=args.name)
+        fw = await frame.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+        tag = await frame.send_lua("print(frame.GIT_TAG)", await_print=True)
+        batt = await frame.send_lua("print(frame.battery_level())", await_print=True)
+        print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
         # Optionally attach the python print function to print incoming strings from Frame stdout
         frame._user_print_response_handler = print

--- a/python/packages/brilliant_ble/examples/echo.py
+++ b/python/packages/brilliant_ble/examples/echo.py
@@ -1,11 +1,19 @@
 import asyncio
+import argparse
 from brilliant_ble import BrilliantBle
 
 async def main():
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device over BLE and run this example.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     frame = BrilliantBle()
 
     try:
-        await frame.connect()
+        await frame.connect(name=args.name)
 
         # Optionally attach the python print function to print incoming strings from Frame stdout
         frame._user_print_response_handler = print

--- a/python/packages/brilliant_ble/examples/halo_ancs_notifications.py
+++ b/python/packages/brilliant_ble/examples/halo_ancs_notifications.py
@@ -15,13 +15,21 @@ To remove the app again, run send_remove.py (removes main.lua from the Halo).
 """
 
 import asyncio
+import argparse
 from brilliant_ble import BrilliantBle, BrilliantDeviceType
 
 async def main():
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device over BLE and run this example.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     frame = BrilliantBle()
 
     try:
-        await frame.connect()
+        await frame.connect(name=args.name)
 
         if frame.type != BrilliantDeviceType.HALO:
             print("halo_ancs_notifications example is Halo-only")

--- a/python/packages/brilliant_ble/examples/halo_ancs_notifications.py
+++ b/python/packages/brilliant_ble/examples/halo_ancs_notifications.py
@@ -62,8 +62,9 @@ async def main():
         print("paired/bonded) - its notifications will appear on the display.")
 
     except Exception as e:
-        print(f"Not connected to Device: {e}")
-        return
+        print(f"An error occurred: {e}")
+    finally:
+        await frame.disconnect()
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/python/packages/brilliant_ble/examples/halo_ancs_notifications.py
+++ b/python/packages/brilliant_ble/examples/halo_ancs_notifications.py
@@ -29,7 +29,7 @@ async def main():
     frame = BrilliantBle()
 
     try:
-        await frame.connect(name=args.name)
+        name = await frame.connect(name=args.name)
 
         if frame.type != BrilliantDeviceType.HALO:
             print("halo_ancs_notifications example is Halo-only")
@@ -38,6 +38,10 @@ async def main():
 
         # Stop any running application so we can talk to the REPL
         await frame.send_break_signal()
+        fw = await frame.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+        tag = await frame.send_lua("print(frame.GIT_TAG)", await_print=True)
+        batt = await frame.send_lua("print(frame.battery_level())", await_print=True)
+        print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
         # Sanity-check the firmware has the ANCS API before installing
         await frame.send_lua(

--- a/python/packages/brilliant_ble/examples/halo_bitmap.py
+++ b/python/packages/brilliant_ble/examples/halo_bitmap.py
@@ -1,4 +1,5 @@
 import asyncio
+import argparse
 
 from brilliant_ble import BrilliantBle, BrilliantDeviceType
 
@@ -39,9 +40,16 @@ async def main():
     """
     Displays images on Halo using the bitmap() function.
     """
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device over BLE and run this example.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     frame = BrilliantBle()
     try:
-        await frame.connect()
+        await frame.connect(name=args.name)
 
         if frame._type != BrilliantDeviceType.HALO:
             return print("This script is for Halo only")

--- a/python/packages/brilliant_ble/examples/halo_bitmap.py
+++ b/python/packages/brilliant_ble/examples/halo_bitmap.py
@@ -49,7 +49,11 @@ async def main():
     args = parser.parse_args()
     frame = BrilliantBle()
     try:
-        await frame.connect(name=args.name)
+        name = await frame.connect(name=args.name)
+        fw = await frame.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+        tag = await frame.send_lua("print(frame.GIT_TAG)", await_print=True)
+        batt = await frame.send_lua("print(frame.battery_level())", await_print=True)
+        print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
         if frame._type != BrilliantDeviceType.HALO:
             return print("This script is for Halo only")

--- a/python/packages/brilliant_ble/examples/hello_noa.py
+++ b/python/packages/brilliant_ble/examples/hello_noa.py
@@ -13,7 +13,11 @@ async def main():
     frame = BrilliantBle()
 
     try:
-        await frame.connect(name=args.name)
+        name = await frame.connect(name=args.name)
+        fw = await frame.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+        tag = await frame.send_lua("print(frame.GIT_TAG)", await_print=True)
+        batt = await frame.send_lua("print(frame.battery_level())", await_print=True)
+        print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
         # initialize Halo display
         if frame._type == BrilliantDeviceType.HALO:

--- a/python/packages/brilliant_ble/examples/hello_noa.py
+++ b/python/packages/brilliant_ble/examples/hello_noa.py
@@ -1,11 +1,19 @@
 import asyncio
+import argparse
 from brilliant_ble import BrilliantBle, BrilliantDeviceType
 
 async def main():
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device over BLE and run this example.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     frame = BrilliantBle()
 
     try:
-        await frame.connect()
+        await frame.connect(name=args.name)
 
         # initialize Halo display
         if frame._type == BrilliantDeviceType.HALO:

--- a/python/packages/brilliant_ble/examples/hello_noa.py
+++ b/python/packages/brilliant_ble/examples/hello_noa.py
@@ -1,3 +1,4 @@
+"""Draw 'NOA' on the display, using a custom-palette bitmap on Halo and text on Frame."""
 import asyncio
 import argparse
 from brilliant_ble import BrilliantBle, BrilliantDeviceType
@@ -67,11 +68,10 @@ async def main():
         else:
             await frame.send_lua("frame.display.text(' ', 1, 1);frame.display.show();print(0)", await_print=True)
 
-        await frame.disconnect()
-
     except Exception as e:
-        print(f"Not connected to Device: {e}")
-        return
+        print(f"An error occurred: {e}")
+    finally:
+        await frame.disconnect()
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/python/packages/brilliant_ble/examples/hello_world.py
+++ b/python/packages/brilliant_ble/examples/hello_world.py
@@ -1,3 +1,4 @@
+"""Print 'Hello' on the device display (Halo or Frame)."""
 import asyncio
 import argparse
 from brilliant_ble import BrilliantBle, BrilliantDeviceType
@@ -33,11 +34,10 @@ async def main():
         print("'Hello' sent")
         await asyncio.sleep(3)  # Wait for a few seconds to see the message
 
-        await frame.disconnect()
-
     except Exception as e:
-        print(f"Not connected to Device: {e}")
-        return
+        print(f"An error occurred: {e}")
+    finally:
+        await frame.disconnect()
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/python/packages/brilliant_ble/examples/hello_world.py
+++ b/python/packages/brilliant_ble/examples/hello_world.py
@@ -1,11 +1,19 @@
 import asyncio
+import argparse
 from brilliant_ble import BrilliantBle, BrilliantDeviceType
 
 async def main():
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device over BLE and run this example.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     frame = BrilliantBle()
 
     try:
-        await frame.connect()
+        await frame.connect(name=args.name)
 
         # initialize the display
         await frame.send_lua("frame.display.power_save(false);print(0)", await_print=True)

--- a/python/packages/brilliant_ble/examples/hello_world.py
+++ b/python/packages/brilliant_ble/examples/hello_world.py
@@ -13,7 +13,11 @@ async def main():
     frame = BrilliantBle()
 
     try:
-        await frame.connect(name=args.name)
+        name = await frame.connect(name=args.name)
+        fw = await frame.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+        tag = await frame.send_lua("print(frame.GIT_TAG)", await_print=True)
+        batt = await frame.send_lua("print(frame.battery_level())", await_print=True)
+        print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
         # initialize the display
         await frame.send_lua("frame.display.power_save(false);print(0)", await_print=True)

--- a/python/packages/brilliant_ble/examples/ota_flash.py
+++ b/python/packages/brilliant_ble/examples/ota_flash.py
@@ -62,7 +62,7 @@ async def main():
     except OtaError as e:
         print(f"\nOTA update failed: {e}")
     except Exception as e:
-        print(f"Not connected to Device: {e}")
+        print(f"An error occurred: {e}")
     finally:
         await halo.disconnect()
 

--- a/python/packages/brilliant_ble/examples/reset_palette.py
+++ b/python/packages/brilliant_ble/examples/reset_palette.py
@@ -1,11 +1,19 @@
 import asyncio
+import argparse
 from brilliant_ble import BrilliantBle, BrilliantDeviceType
 
 async def main():
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device over BLE and run this example.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     frame = BrilliantBle()
 
     try:
-        await frame.connect()
+        await frame.connect(name=args.name)
         # stop any application, if running, so we can send lua commands
         frame._user_print_response_handler = None
         await frame.send_break_signal()

--- a/python/packages/brilliant_ble/examples/reset_palette.py
+++ b/python/packages/brilliant_ble/examples/reset_palette.py
@@ -1,3 +1,4 @@
+"""Restore the device display colour palette to the firmware defaults (Halo or Frame)."""
 import asyncio
 import argparse
 from brilliant_ble import BrilliantBle, BrilliantDeviceType
@@ -62,11 +63,10 @@ async def main():
             await frame.send_lua("frame.display.assign_color_ycbcr(15, 13, 4, 3);print(0)", await_print=True) # CLOUDBLUE
 
         print("Default palette set.")
-        await frame.disconnect()
-
     except Exception as e:
-        print(f"Not connected to Device: {e}")
-        return
+        print(f"An error occurred: {e}")
+    finally:
+        await frame.disconnect()
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/python/packages/brilliant_ble/examples/reset_palette.py
+++ b/python/packages/brilliant_ble/examples/reset_palette.py
@@ -13,10 +13,14 @@ async def main():
     frame = BrilliantBle()
 
     try:
-        await frame.connect(name=args.name)
+        name = await frame.connect(name=args.name)
         # stop any application, if running, so we can send lua commands
         frame._user_print_response_handler = None
         await frame.send_break_signal()
+        fw = await frame.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+        tag = await frame.send_lua("print(frame.GIT_TAG)", await_print=True)
+        batt = await frame.send_lua("print(frame.battery_level())", await_print=True)
+        print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
         if frame.type == BrilliantDeviceType.FRAME:
             # Set the palette back to the firmware default

--- a/python/packages/brilliant_ble/examples/send_break.py
+++ b/python/packages/brilliant_ble/examples/send_break.py
@@ -1,3 +1,4 @@
+"""Send a break signal to stop any running Lua app so the device is ready for REPL commands."""
 import asyncio
 import argparse
 from brilliant_ble import BrilliantBle
@@ -23,11 +24,10 @@ async def main():
         print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
         print("Break sent")
 
-        await frame.disconnect()
-
     except Exception as e:
-        print(f"Not connected to Device: {e}")
-        return
+        print(f"An error occurred: {e}")
+    finally:
+        await frame.disconnect()
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/python/packages/brilliant_ble/examples/send_break.py
+++ b/python/packages/brilliant_ble/examples/send_break.py
@@ -13,10 +13,14 @@ async def main():
     frame = BrilliantBle()
 
     try:
-        await frame.connect(name=args.name)
+        name = await frame.connect(name=args.name)
 
         # stop any application, if running, so we can send lua commands
         await frame.send_break_signal()
+        fw = await frame.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+        tag = await frame.send_lua("print(frame.GIT_TAG)", await_print=True)
+        batt = await frame.send_lua("print(frame.battery_level())", await_print=True)
+        print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
         print("Break sent")
 
         await frame.disconnect()

--- a/python/packages/brilliant_ble/examples/send_break.py
+++ b/python/packages/brilliant_ble/examples/send_break.py
@@ -1,11 +1,19 @@
 import asyncio
+import argparse
 from brilliant_ble import BrilliantBle
 
 async def main():
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device over BLE and run this example.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     frame = BrilliantBle()
 
     try:
-        await frame.connect()
+        await frame.connect(name=args.name)
 
         # stop any application, if running, so we can send lua commands
         await frame.send_break_signal()

--- a/python/packages/brilliant_ble/examples/send_remove.py
+++ b/python/packages/brilliant_ble/examples/send_remove.py
@@ -13,7 +13,11 @@ async def main():
     frame = BrilliantBle()
 
     try:
-        await frame.connect(name=args.name)
+        name = await frame.connect(name=args.name)
+        fw = await frame.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+        tag = await frame.send_lua("print(frame.GIT_TAG)", await_print=True)
+        batt = await frame.send_lua("print(frame.battery_level())", await_print=True)
+        print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
         # remove any main.lua from Halo
         if (frame._type == BrilliantDeviceType.HALO):

--- a/python/packages/brilliant_ble/examples/send_remove.py
+++ b/python/packages/brilliant_ble/examples/send_remove.py
@@ -1,3 +1,4 @@
+"""Halo-only: remove main.lua from the device so it stops auto-running an installed app."""
 import asyncio
 import argparse
 from brilliant_ble import BrilliantBle, BrilliantDeviceType
@@ -26,11 +27,10 @@ async def main():
         else:
             print("This script is intended for the Halo device only.")
 
-        await frame.disconnect()
-
     except Exception as e:
-        print(f"Not connected to Device: {e}")
-        return
+        print(f"An error occurred: {e}")
+    finally:
+        await frame.disconnect()
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/python/packages/brilliant_ble/examples/send_remove.py
+++ b/python/packages/brilliant_ble/examples/send_remove.py
@@ -1,11 +1,19 @@
 import asyncio
+import argparse
 from brilliant_ble import BrilliantBle, BrilliantDeviceType
 
 async def main():
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device over BLE and run this example.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     frame = BrilliantBle()
 
     try:
-        await frame.connect()
+        await frame.connect(name=args.name)
 
         # remove any main.lua from Halo
         if (frame._type == BrilliantDeviceType.HALO):

--- a/python/packages/brilliant_ble/examples/send_reset.py
+++ b/python/packages/brilliant_ble/examples/send_reset.py
@@ -1,3 +1,4 @@
+"""Soft-reset the device (restart the Lua VM)."""
 import asyncio
 import argparse
 from brilliant_ble import BrilliantBle
@@ -23,11 +24,10 @@ async def main():
         await frame.send_reset_signal()
         print("Reset sent")
 
-        await frame.disconnect()
-
     except Exception as e:
-        print(f"Not connected to Device: {e}")
-        return
+        print(f"An error occurred: {e}")
+    finally:
+        await frame.disconnect()
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/python/packages/brilliant_ble/examples/send_reset.py
+++ b/python/packages/brilliant_ble/examples/send_reset.py
@@ -1,11 +1,19 @@
 import asyncio
+import argparse
 from brilliant_ble import BrilliantBle
 
 async def main():
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device over BLE and run this example.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     frame = BrilliantBle()
 
     try:
-        await frame.connect()
+        await frame.connect(name=args.name)
 
         # soft reset the Frame
         await frame.send_reset_signal()

--- a/python/packages/brilliant_ble/examples/send_reset.py
+++ b/python/packages/brilliant_ble/examples/send_reset.py
@@ -13,7 +13,11 @@ async def main():
     frame = BrilliantBle()
 
     try:
-        await frame.connect(name=args.name)
+        name = await frame.connect(name=args.name)
+        fw = await frame.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+        tag = await frame.send_lua("print(frame.GIT_TAG)", await_print=True)
+        batt = await frame.send_lua("print(frame.battery_level())", await_print=True)
+        print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
         # soft reset the Frame
         await frame.send_reset_signal()

--- a/python/packages/brilliant_ble/examples/stay_awake_false.py
+++ b/python/packages/brilliant_ble/examples/stay_awake_false.py
@@ -1,3 +1,4 @@
+"""Restore normal sleep behaviour (device sleeps/turns off in the cradle) and put it to sleep now."""
 import asyncio
 import argparse
 from brilliant_ble import BrilliantBle
@@ -31,11 +32,13 @@ async def main():
             print("Halo will sleep now")
 
         await frame.send_lua("frame.sleep()", await_print=False)
-        # already disconnected from sleep - don't await frame.disconnect()
 
     except Exception as e:
-        print(f"Not connected to Device: {e}")
-        return
+        print(f"An error occurred: {e}")
+    finally:
+        # sleep() above usually drops the connection already, so this is a no-op
+        # on the happy path, but it still cleans up if an error happened earlier
+        await frame.disconnect()
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/python/packages/brilliant_ble/examples/stay_awake_false.py
+++ b/python/packages/brilliant_ble/examples/stay_awake_false.py
@@ -14,10 +14,14 @@ async def main():
     frame = BrilliantBle()
 
     try:
-        await frame.connect(name=args.name)
+        name = await frame.connect(name=args.name)
 
         # stop any application, if running, so we can send lua commands
         await frame.send_break_signal()
+        fw = await frame.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+        tag = await frame.send_lua("print(frame.GIT_TAG)", await_print=True)
+        batt = await frame.send_lua("print(frame.battery_level())", await_print=True)
+        print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
         # Restore normal behavior that Frame turns off when placed in the charging cradle (and puts it to sleep now)
         if frame.type == BrilliantDeviceType.FRAME:

--- a/python/packages/brilliant_ble/examples/stay_awake_false.py
+++ b/python/packages/brilliant_ble/examples/stay_awake_false.py
@@ -1,12 +1,20 @@
 import asyncio
+import argparse
 from brilliant_ble import BrilliantBle
 from brilliant_ble import BrilliantDeviceType
 
 async def main():
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device over BLE and run this example.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     frame = BrilliantBle()
 
     try:
-        await frame.connect()
+        await frame.connect(name=args.name)
 
         # stop any application, if running, so we can send lua commands
         await frame.send_break_signal()

--- a/python/packages/brilliant_ble/examples/stay_awake_true.py
+++ b/python/packages/brilliant_ble/examples/stay_awake_true.py
@@ -14,10 +14,14 @@ async def main():
     frame = BrilliantBle()
 
     try:
-        await frame.connect(name=args.name)
+        name = await frame.connect(name=args.name)
 
         # stop any application, if running, so we can send lua commands
         await frame.send_break_signal()
+        fw = await frame.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+        tag = await frame.send_lua("print(frame.GIT_TAG)", await_print=True)
+        batt = await frame.send_lua("print(frame.battery_level())", await_print=True)
+        print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
         # Keep Frame awake even in charging cradle (for development)
         await frame.send_lua("frame.stay_awake(true);print(0)", await_print=True)

--- a/python/packages/brilliant_ble/examples/stay_awake_true.py
+++ b/python/packages/brilliant_ble/examples/stay_awake_true.py
@@ -1,3 +1,4 @@
+"""Keep the device awake even in the charging cradle (useful during development)."""
 import asyncio
 import argparse
 from brilliant_ble import BrilliantBle
@@ -30,11 +31,10 @@ async def main():
         else:
             print("Halo will stay awake")
 
-        await frame.disconnect()
-
     except Exception as e:
-        print(f"Not connected to Device: {e}")
-        return
+        print(f"An error occurred: {e}")
+    finally:
+        await frame.disconnect()
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/python/packages/brilliant_ble/examples/stay_awake_true.py
+++ b/python/packages/brilliant_ble/examples/stay_awake_true.py
@@ -1,12 +1,20 @@
 import asyncio
+import argparse
 from brilliant_ble import BrilliantBle
 from brilliant_ble import BrilliantDeviceType
 
 async def main():
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device over BLE and run this example.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     frame = BrilliantBle()
 
     try:
-        await frame.connect()
+        await frame.connect(name=args.name)
 
         # stop any application, if running, so we can send lua commands
         await frame.send_break_signal()

--- a/python/packages/brilliant_ble/examples/tap.py
+++ b/python/packages/brilliant_ble/examples/tap.py
@@ -1,3 +1,4 @@
+"""Register a tap callback on the device and print a message each time it is tapped."""
 import asyncio
 import argparse
 from brilliant_ble import BrilliantBle
@@ -29,11 +30,10 @@ async def main():
 
         await asyncio.sleep(20)  # Keep the program running to listen for taps
 
-        await frame.disconnect()
-
     except Exception as e:
-        print(f"Not connected to Device: {e}")
-        return
+        print(f"An error occurred: {e}")
+    finally:
+        await frame.disconnect()
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/python/packages/brilliant_ble/examples/tap.py
+++ b/python/packages/brilliant_ble/examples/tap.py
@@ -13,7 +13,11 @@ async def main():
     frame = BrilliantBle()
 
     try:
-        await frame.connect(name=args.name)
+        name = await frame.connect(name=args.name)
+        fw = await frame.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+        tag = await frame.send_lua("print(frame.GIT_TAG)", await_print=True)
+        batt = await frame.send_lua("print(frame.battery_level())", await_print=True)
+        print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
         # Optionally attach the python print function to print incoming strings from Frame stdout
         frame._user_print_response_handler = print

--- a/python/packages/brilliant_ble/examples/tap.py
+++ b/python/packages/brilliant_ble/examples/tap.py
@@ -1,11 +1,19 @@
 import asyncio
+import argparse
 from brilliant_ble import BrilliantBle
 
 async def main():
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device over BLE and run this example.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     frame = BrilliantBle()
 
     try:
-        await frame.connect()
+        await frame.connect(name=args.name)
 
         # Optionally attach the python print function to print incoming strings from Frame stdout
         frame._user_print_response_handler = print

--- a/python/packages/brilliant_ble/src/brilliant_ble/brilliant_ble.py
+++ b/python/packages/brilliant_ble/src/brilliant_ble/brilliant_ble.py
@@ -81,6 +81,7 @@ class BrilliantBle:
         self._user_disconnect_handler = lambda: None
         self._user_print_response_handler = lambda: None
         self._type = BrilliantDeviceType.UNKNOWN
+        self._name = None
 
     @property
     def type(self):
@@ -88,6 +89,14 @@ class BrilliantBle:
         Returns the type of the Brilliant device.
         """
         return self._type
+
+    @property
+    def name(self):
+        """
+        Returns the BLE local name of the connected device (e.g. "Halo 08"),
+        or None if not connected.
+        """
+        return self._name
 
     def _disconnect_handler(self, _):
         self._user_disconnect_handler()
@@ -204,6 +213,7 @@ class BrilliantBle:
         except Exception as ble_error:
             raise Exception(f"Error subscribing for notifications: {ble_error}")
 
+        self._name = device.name
         return device.name
 
     async def disconnect(self):

--- a/python/packages/brilliant_ble/tests/test_aad.py
+++ b/python/packages/brilliant_ble/tests/test_aad.py
@@ -1,11 +1,19 @@
 import asyncio
+import argparse
 from brilliant_ble import BrilliantBle, BrilliantDeviceType
 
 async def main():
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device over BLE and run this test.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     b = BrilliantBle()
 
     # Connect to the device
-    await b.connect(print_response_handler=lambda s: print(s))
+    await b.connect(name=args.name, print_response_handler=lambda s: print(s))
 
     if b.type != BrilliantDeviceType.HALO:
         print("AAD example is Halo-only")

--- a/python/packages/brilliant_ble/tests/test_aad.py
+++ b/python/packages/brilliant_ble/tests/test_aad.py
@@ -13,7 +13,11 @@ async def main():
     b = BrilliantBle()
 
     # Connect to the device
-    await b.connect(name=args.name, print_response_handler=lambda s: print(s))
+    name = await b.connect(name=args.name, print_response_handler=lambda s: print(s))
+    fw = await b.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+    tag = await b.send_lua("print(frame.GIT_TAG)", await_print=True)
+    batt = await b.send_lua("print(frame.battery_level())", await_print=True)
+    print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
     if b.type != BrilliantDeviceType.HALO:
         print("AAD example is Halo-only")

--- a/python/packages/brilliant_ble/tests/test_battery.py
+++ b/python/packages/brilliant_ble/tests/test_battery.py
@@ -17,7 +17,11 @@ async def main():
     args = parser.parse_args()
     b = BrilliantBle()
 
-    await b.connect(name=args.name, print_response_handler=lambda s: print(s))
+    name = await b.connect(name=args.name, print_response_handler=lambda s: print(s))
+    fw = await b.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+    tag = await b.send_lua("print(frame.GIT_TAG)", await_print=True)
+    batt = await b.send_lua("print(frame.battery_level())", await_print=True)
+    print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
     try:
         while True:

--- a/python/packages/brilliant_ble/tests/test_battery.py
+++ b/python/packages/brilliant_ble/tests/test_battery.py
@@ -3,13 +3,21 @@ Tests the Frame specific Lua libraries over Bluetooth.
 """
 
 import asyncio
+import argparse
 from brilliant_ble import BrilliantBle, BrilliantDeviceType
 
 
 async def main():
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device over BLE and run this test.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     b = BrilliantBle()
 
-    await b.connect(print_response_handler=lambda s: print(s))
+    await b.connect(name=args.name, print_response_handler=lambda s: print(s))
 
     try:
         while True:

--- a/python/packages/brilliant_ble/tests/test_ble.py
+++ b/python/packages/brilliant_ble/tests/test_ble.py
@@ -1,8 +1,11 @@
 import unittest
 import asyncio
+import os
 import sys
 
 from brilliant_ble import BrilliantBle
+
+LUA_DIR = os.path.join(os.path.dirname(__file__), "lua")
 
 
 class TestBluetooth(unittest.IsolatedAsyncioTestCase):
@@ -81,7 +84,7 @@ class TestBluetooth(unittest.IsolatedAsyncioTestCase):
         await b.connect()
         self.assertIsNone(await b.send_break_signal())
 
-        self.assertIsNone(await b.upload_file("./lua/test.lua", "test.lua"))
+        self.assertIsNone(await b.upload_file(os.path.join(LUA_DIR, "test.lua"), "test.lua"))
 
         self.assertIsNone(await b.send_lua("require('test')"))
         await asyncio.sleep(1)

--- a/python/packages/brilliant_ble/tests/test_bluetooth_callback_api.py
+++ b/python/packages/brilliant_ble/tests/test_bluetooth_callback_api.py
@@ -1,11 +1,20 @@
 import asyncio
+import argparse
 from brilliant_ble import BrilliantBle
 
 
 async def main():
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device over BLE and run this test.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     bluetooth = BrilliantBle()
 
     await bluetooth.connect(
+        name=args.name,
         print_response_handler=lambda string: print(f"Print: {string}"),
         data_response_handler=lambda data: print(f"Data: {bytes(data).decode()}"),
     )

--- a/python/packages/brilliant_ble/tests/test_bluetooth_callback_api.py
+++ b/python/packages/brilliant_ble/tests/test_bluetooth_callback_api.py
@@ -13,13 +13,17 @@ async def main():
     args = parser.parse_args()
     bluetooth = BrilliantBle()
 
-    await bluetooth.connect(
+    name = await bluetooth.connect(
         name=args.name,
         print_response_handler=lambda string: print(f"Print: {string}"),
         data_response_handler=lambda data: print(f"Data: {bytes(data).decode()}"),
     )
 
     await bluetooth.send_reset_signal()
+    fw = await bluetooth.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+    tag = await bluetooth.send_lua("print(frame.GIT_TAG)", await_print=True)
+    batt = await bluetooth.send_lua("print(frame.battery_level())", await_print=True)
+    print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
     await bluetooth.send_lua("function ble_event(d)frame.bluetooth.send(d)end")
     await bluetooth.send_lua("frame.bluetooth.receive_callback(ble_event)")
     await bluetooth.send_lua("for i=1,10 do print(i); frame.sleep(1) end")

--- a/python/packages/brilliant_ble/tests/test_bluetooth_throughput.py
+++ b/python/packages/brilliant_ble/tests/test_bluetooth_throughput.py
@@ -1,4 +1,5 @@
 import asyncio
+import argparse
 import time
 from aioconsole import ainput
 from brilliant_ble import BrilliantBle
@@ -20,6 +21,13 @@ def receive_data(data):
 
 
 async def main():
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device over BLE and run this test.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
 
     lua_script = """
     data = string.rep('a',frame.bluetooth.max_length())
@@ -32,7 +40,7 @@ async def main():
 
     b = BrilliantBle()
 
-    await b.connect(data_response_handler=receive_data)
+    await b.connect(name=args.name, data_response_handler=receive_data)
 
     await b.send_break_signal()
     await b.upload_file_from_string(lua_script, "test.lua")

--- a/python/packages/brilliant_ble/tests/test_bluetooth_throughput.py
+++ b/python/packages/brilliant_ble/tests/test_bluetooth_throughput.py
@@ -40,9 +40,13 @@ async def main():
 
     b = BrilliantBle()
 
-    await b.connect(name=args.name, data_response_handler=receive_data)
+    name = await b.connect(name=args.name, data_response_handler=receive_data)
 
     await b.send_break_signal()
+    fw = await b.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+    tag = await b.send_lua("print(frame.GIT_TAG)", await_print=True)
+    batt = await b.send_lua("print(frame.battery_level())", await_print=True)
+    print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
     await b.upload_file_from_string(lua_script, "test.lua")
     # why do we need to sleep to make sure the upload gets its reply?
     # Maybe the future from the send_lua() await_print misses getting completed

--- a/python/packages/brilliant_ble/tests/test_button.py
+++ b/python/packages/brilliant_ble/tests/test_button.py
@@ -3,13 +3,21 @@ Tests the Frame specific Lua button library over Bluetooth.
 """
 
 import asyncio
+import argparse
 from brilliant_ble import BrilliantBle, BrilliantDeviceType
 
 
 async def main():
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device over BLE and run this test.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     b = BrilliantBle()
 
-    await b.connect(print_response_handler=lambda s: print(s))
+    await b.connect(name=args.name, print_response_handler=lambda s: print(s))
 
     if b.type != BrilliantDeviceType.HALO:
         print("Button example is Halo-only")

--- a/python/packages/brilliant_ble/tests/test_button.py
+++ b/python/packages/brilliant_ble/tests/test_button.py
@@ -17,7 +17,11 @@ async def main():
     args = parser.parse_args()
     b = BrilliantBle()
 
-    await b.connect(name=args.name, print_response_handler=lambda s: print(s))
+    name = await b.connect(name=args.name, print_response_handler=lambda s: print(s))
+    fw = await b.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+    tag = await b.send_lua("print(frame.GIT_TAG)", await_print=True)
+    batt = await b.send_lua("print(frame.battery_level())", await_print=True)
+    print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
     if b.type != BrilliantDeviceType.HALO:
         print("Button example is Halo-only")

--- a/python/packages/brilliant_ble/tests/test_compression.py
+++ b/python/packages/brilliant_ble/tests/test_compression.py
@@ -14,7 +14,11 @@ async def main():
 
     b = BrilliantBle()
 
-    await b.connect(name=args.name, print_response_handler=lambda s: print(s))
+    name = await b.connect(name=args.name, print_response_handler=lambda s: print(s))
+    fw = await b.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+    tag = await b.send_lua("print(frame.GIT_TAG)", await_print=True)
+    batt = await b.send_lua("print(frame.battery_level())", await_print=True)
+    print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
     # Upload the Lua script
     lua_script = """

--- a/python/packages/brilliant_ble/tests/test_compression.py
+++ b/python/packages/brilliant_ble/tests/test_compression.py
@@ -1,12 +1,20 @@
 import asyncio
+import argparse
 from brilliant_ble import BrilliantBle
 
 
 async def main():
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device over BLE and run this test.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
 
     b = BrilliantBle()
 
-    await b.connect(print_response_handler=lambda s: print(s))
+    await b.connect(name=args.name, print_response_handler=lambda s: print(s))
 
     # Upload the Lua script
     lua_script = """

--- a/python/packages/brilliant_ble/tests/test_display.py
+++ b/python/packages/brilliant_ble/tests/test_display.py
@@ -1,9 +1,17 @@
 import asyncio
+import argparse
 from brilliant_ble import BrilliantBle, BrilliantDeviceType
 
 async def main():
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device over BLE and run this test.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     b = BrilliantBle()
-    await b.connect(print_response_handler=lambda s: print(s))
+    await b.connect(name=args.name, print_response_handler=lambda s: print(s))
     
     if b.type != BrilliantDeviceType.HALO:
         print("Display example is Halo-only")

--- a/python/packages/brilliant_ble/tests/test_display.py
+++ b/python/packages/brilliant_ble/tests/test_display.py
@@ -11,7 +11,11 @@ async def main():
     )
     args = parser.parse_args()
     b = BrilliantBle()
-    await b.connect(name=args.name, print_response_handler=lambda s: print(s))
+    name = await b.connect(name=args.name, print_response_handler=lambda s: print(s))
+    fw = await b.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+    tag = await b.send_lua("print(frame.GIT_TAG)", await_print=True)
+    batt = await b.send_lua("print(frame.battery_level())", await_print=True)
+    print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
     
     if b.type != BrilliantDeviceType.HALO:
         print("Display example is Halo-only")

--- a/python/packages/brilliant_ble/tests/test_display_bitmap.py
+++ b/python/packages/brilliant_ble/tests/test_display_bitmap.py
@@ -1,4 +1,5 @@
 import asyncio
+import argparse
 from brilliant_ble import BrilliantBle, BrilliantDeviceType
 
 async def set_standard_palette(b: BrilliantBle):
@@ -49,8 +50,15 @@ async def full_display_palette(b: BrilliantBle):
         await b.send_lua(lua_command, await_print=True)
 
 async def main():
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device over BLE and run this test.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     b = BrilliantBle()
-    await b.connect(print_response_handler=lambda s: print(s))
+    await b.connect(name=args.name, print_response_handler=lambda s: print(s))
 
     if b.type != BrilliantDeviceType.HALO:
         print("Display bitmap example is Halo-only")

--- a/python/packages/brilliant_ble/tests/test_display_bitmap.py
+++ b/python/packages/brilliant_ble/tests/test_display_bitmap.py
@@ -58,7 +58,11 @@ async def main():
     )
     args = parser.parse_args()
     b = BrilliantBle()
-    await b.connect(name=args.name, print_response_handler=lambda s: print(s))
+    name = await b.connect(name=args.name, print_response_handler=lambda s: print(s))
+    fw = await b.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+    tag = await b.send_lua("print(frame.GIT_TAG)", await_print=True)
+    batt = await b.send_lua("print(frame.battery_level())", await_print=True)
+    print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
     if b.type != BrilliantDeviceType.HALO:
         print("Display bitmap example is Halo-only")

--- a/python/packages/brilliant_ble/tests/test_file_api.py
+++ b/python/packages/brilliant_ble/tests/test_file_api.py
@@ -91,6 +91,10 @@ async def main():
     args = parser.parse_args()
     test = TestBluetooth()
     await test.initialize(name=args.name)
+    fw = await test.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+    tag = await test.send_lua("print(frame.GIT_TAG)", await_print=True)
+    batt = await test.send_lua("print(frame.battery_level())", await_print=True)
+    print(f"{test.name} | firmware {fw} | git {tag} | battery {batt}%")
 
     ## Test all modes (writable, read only, and append)
     await test.lua_send("f=frame.file.open('test.lua', 'w')")

--- a/python/packages/brilliant_ble/tests/test_file_api.py
+++ b/python/packages/brilliant_ble/tests/test_file_api.py
@@ -3,6 +3,7 @@ Tests the Frame specific Lua libraries over Bluetooth.
 """
 
 import asyncio, sys
+import argparse
 from brilliant_ble import BrilliantBle
 
 
@@ -27,8 +28,8 @@ class TestBluetooth(BrilliantBle):
         else:
             print(f"\033[91mFAILED: {sent} => {responded} != {expected}")
 
-    async def initialize(self):
-        await self.connect()
+    async def initialize(self, name=None):
+        await self.connect(name=name)
 
     async def end(self):
         passed_tests = self._passed_tests
@@ -81,8 +82,15 @@ class TestBluetooth(BrilliantBle):
 
 
 async def main():
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device over BLE and run this test.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     test = TestBluetooth()
-    await test.initialize()
+    await test.initialize(name=args.name)
 
     ## Test all modes (writable, read only, and append)
     await test.lua_send("f=frame.file.open('test.lua', 'w')")

--- a/python/packages/brilliant_ble/tests/test_file_execution.py
+++ b/python/packages/brilliant_ble/tests/test_file_execution.py
@@ -91,6 +91,10 @@ async def main():
     args = parser.parse_args()
     test = TestBluetooth()
     await test.initialize(name=args.name)
+    fw = await test.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+    tag = await test.send_lua("print(frame.GIT_TAG)", await_print=True)
+    batt = await test.send_lua("print(frame.battery_level())", await_print=True)
+    print(f"{test.name} | firmware {fw} | git {tag} | battery {batt}%")
 
     # Upload main.lua
     await test.lua_send("f=frame.file.open('main.lua', 'w')")

--- a/python/packages/brilliant_ble/tests/test_file_execution.py
+++ b/python/packages/brilliant_ble/tests/test_file_execution.py
@@ -3,6 +3,7 @@ Tests the Frame specific Lua libraries over Bluetooth.
 """
 
 import asyncio, sys
+import argparse
 from brilliant_ble import BrilliantBle
 
 
@@ -27,8 +28,8 @@ class TestBluetooth(BrilliantBle):
         else:
             print(f"\033[91mFAILED: {sent} => {responded} != {expected}")
 
-    async def initialize(self):
-        await self.connect(print_response_handler=lambda s: print("-->" + s))
+    async def initialize(self, name=None):
+        await self.connect(name=name, print_response_handler=lambda s: print("-->" + s))
 
     async def end(self):
         passed_tests = self._passed_tests
@@ -81,8 +82,15 @@ class TestBluetooth(BrilliantBle):
 
 
 async def main():
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device over BLE and run this test.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     test = TestBluetooth()
-    await test.initialize()
+    await test.initialize(name=args.name)
 
     # Upload main.lua
     await test.lua_send("f=frame.file.open('main.lua', 'w')")

--- a/python/packages/brilliant_ble/tests/test_imu_direction.py
+++ b/python/packages/brilliant_ble/tests/test_imu_direction.py
@@ -3,14 +3,22 @@ Tests the Frame specific Lua libraries over Bluetooth.
 """
 
 import asyncio
+import argparse
 from brilliant_ble import BrilliantBle
 
 
 async def main():
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device over BLE and run this test.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     b = BrilliantBle()
 
     try:
-        await b.connect(print_response_handler=lambda s: print(s))
+        await b.connect(name=args.name, print_response_handler=lambda s: print(s))
 
         # Enable taps
         await b.send_lua("frame.imu.tap_callback((function()print('Tap!')end))")

--- a/python/packages/brilliant_ble/tests/test_imu_direction.py
+++ b/python/packages/brilliant_ble/tests/test_imu_direction.py
@@ -18,7 +18,11 @@ async def main():
     b = BrilliantBle()
 
     try:
-        await b.connect(name=args.name, print_response_handler=lambda s: print(s))
+        name = await b.connect(name=args.name, print_response_handler=lambda s: print(s))
+        fw = await b.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+        tag = await b.send_lua("print(frame.GIT_TAG)", await_print=True)
+        batt = await b.send_lua("print(frame.battery_level())", await_print=True)
+        print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
         # Enable taps
         await b.send_lua("frame.imu.tap_callback((function()print('Tap!')end))")

--- a/python/packages/brilliant_ble/tests/test_imu_raw.py
+++ b/python/packages/brilliant_ble/tests/test_imu_raw.py
@@ -3,14 +3,22 @@ Tests the Frame specific Lua libraries over Bluetooth.
 """
 
 import asyncio
+import argparse
 from brilliant_ble import BrilliantBle
 
 
 async def main():
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device over BLE and run this test.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     b = BrilliantBle()
 
     try:
-        await b.connect(print_response_handler=lambda s: print(s))
+        await b.connect(name=args.name, print_response_handler=lambda s: print(s))
 
         # Enable taps
         await b.send_lua("frame.imu.tap_callback((function()print('Tap!')end))")

--- a/python/packages/brilliant_ble/tests/test_imu_raw.py
+++ b/python/packages/brilliant_ble/tests/test_imu_raw.py
@@ -18,7 +18,11 @@ async def main():
     b = BrilliantBle()
 
     try:
-        await b.connect(name=args.name, print_response_handler=lambda s: print(s))
+        name = await b.connect(name=args.name, print_response_handler=lambda s: print(s))
+        fw = await b.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+        tag = await b.send_lua("print(frame.GIT_TAG)", await_print=True)
+        batt = await b.send_lua("print(frame.battery_level())", await_print=True)
+        print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
         # Enable taps
         await b.send_lua("frame.imu.tap_callback((function()print('Tap!')end))")

--- a/python/packages/brilliant_ble/tests/test_microphone.py
+++ b/python/packages/brilliant_ble/tests/test_microphone.py
@@ -4,6 +4,7 @@ Records audio and saves it as a WAV file with timestamped filename.
 """
 
 import asyncio
+import argparse
 from brilliant_ble import BrilliantBle
 import numpy as np
 import wave
@@ -101,8 +102,15 @@ async def record_and_save(b: BrilliantBle, sample_rate, bit_depth, channels=2):
 
 
 async def main():
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device over BLE and run this test.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     b = BrilliantBle()
-    await b.connect(data_response_handler=receive_data)
+    await b.connect(name=args.name, data_response_handler=receive_data)
     await record_and_save(b, sample_rate=16000, bit_depth=16, channels=1)
     await b.disconnect()
 

--- a/python/packages/brilliant_ble/tests/test_microphone.py
+++ b/python/packages/brilliant_ble/tests/test_microphone.py
@@ -110,7 +110,11 @@ async def main():
     )
     args = parser.parse_args()
     b = BrilliantBle()
-    await b.connect(name=args.name, data_response_handler=receive_data)
+    name = await b.connect(name=args.name, data_response_handler=receive_data)
+    fw = await b.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+    tag = await b.send_lua("print(frame.GIT_TAG)", await_print=True)
+    batt = await b.send_lua("print(frame.battery_level())", await_print=True)
+    print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
     await record_and_save(b, sample_rate=16000, bit_depth=16, channels=1)
     await b.disconnect()
 

--- a/python/packages/brilliant_ble/tests/test_microphone_lc3.py
+++ b/python/packages/brilliant_ble/tests/test_microphone_lc3.py
@@ -4,6 +4,7 @@ Records LC3-encoded audio via Bluetooth and saves it as both .lc3 and .wav files
 """
 
 import asyncio
+import argparse
 from brilliant_ble import BrilliantBle, BrilliantDeviceType
 import numpy as np
 import lc3
@@ -121,8 +122,15 @@ async def record_and_save(b: BrilliantBle, sample_rate, bitrate, frame_duration_
 
 
 async def main():
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device over BLE and run this test.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     b = BrilliantBle()
-    await b.connect(data_response_handler=receive_data)
+    await b.connect(name=args.name, data_response_handler=receive_data)
 
     if b.type != BrilliantDeviceType.HALO:
         print("LC3 microphone example is Halo-only")

--- a/python/packages/brilliant_ble/tests/test_microphone_lc3.py
+++ b/python/packages/brilliant_ble/tests/test_microphone_lc3.py
@@ -130,7 +130,11 @@ async def main():
     )
     args = parser.parse_args()
     b = BrilliantBle()
-    await b.connect(name=args.name, data_response_handler=receive_data)
+    name = await b.connect(name=args.name, data_response_handler=receive_data)
+    fw = await b.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+    tag = await b.send_lua("print(frame.GIT_TAG)", await_print=True)
+    batt = await b.send_lua("print(frame.battery_level())", await_print=True)
+    print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
     if b.type != BrilliantDeviceType.HALO:
         print("LC3 microphone example is Halo-only")

--- a/python/packages/brilliant_ble/tests/test_speaker_lc3.py
+++ b/python/packages/brilliant_ble/tests/test_speaker_lc3.py
@@ -11,7 +11,11 @@ async def main():
     )
     args = parser.parse_args()
     b = BrilliantBle()
-    await b.connect(name=args.name)
+    name = await b.connect(name=args.name)
+    fw = await b.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+    tag = await b.send_lua("print(frame.GIT_TAG)", await_print=True)
+    batt = await b.send_lua("print(frame.battery_level())", await_print=True)
+    print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
     if b.type != BrilliantDeviceType.HALO:
         print("Speaker LC3 example is Halo-only")

--- a/python/packages/brilliant_ble/tests/test_speaker_lc3.py
+++ b/python/packages/brilliant_ble/tests/test_speaker_lc3.py
@@ -1,9 +1,17 @@
 import asyncio
+import argparse
 from brilliant_ble import BrilliantBle, BrilliantDeviceType
 
 async def main():
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device over BLE and run this test.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     b = BrilliantBle()
-    await b.connect()
+    await b.connect(name=args.name)
 
     if b.type != BrilliantDeviceType.HALO:
         print("Speaker LC3 example is Halo-only")

--- a/python/packages/brilliant_ble/tests/test_speaker_lc3_2.py
+++ b/python/packages/brilliant_ble/tests/test_speaker_lc3_2.py
@@ -11,7 +11,11 @@ async def main():
     )
     args = parser.parse_args()
     b = BrilliantBle()
-    await b.connect(name=args.name)
+    name = await b.connect(name=args.name)
+    fw = await b.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+    tag = await b.send_lua("print(frame.GIT_TAG)", await_print=True)
+    batt = await b.send_lua("print(frame.battery_level())", await_print=True)
+    print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
     if b.type != BrilliantDeviceType.HALO:
         print("Speaker LC3 example is Halo-only")

--- a/python/packages/brilliant_ble/tests/test_speaker_lc3_2.py
+++ b/python/packages/brilliant_ble/tests/test_speaker_lc3_2.py
@@ -1,9 +1,17 @@
 import asyncio
+import argparse
 from brilliant_ble import BrilliantBle, BrilliantDeviceType
 
 async def main():
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device over BLE and run this test.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     b = BrilliantBle()
-    await b.connect()
+    await b.connect(name=args.name)
 
     if b.type != BrilliantDeviceType.HALO:
         print("Speaker LC3 example is Halo-only")

--- a/python/packages/brilliant_ble/tests/test_speaker_pcm.py
+++ b/python/packages/brilliant_ble/tests/test_speaker_pcm.py
@@ -1,4 +1,5 @@
 import asyncio
+import argparse
 from brilliant_ble import BrilliantBle, BrilliantDeviceType
 
 # convert s8 to s16 le
@@ -16,8 +17,15 @@ def s8_to_s16_le(data: bytes) -> bytes:
 
 
 async def main():
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device over BLE and run this test.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     b = BrilliantBle()
-    await b.connect()
+    await b.connect(name=args.name)
 
     if b.type != BrilliantDeviceType.HALO:
         print("Speaker PCM example is Halo-only")

--- a/python/packages/brilliant_ble/tests/test_speaker_pcm.py
+++ b/python/packages/brilliant_ble/tests/test_speaker_pcm.py
@@ -25,7 +25,11 @@ async def main():
     )
     args = parser.parse_args()
     b = BrilliantBle()
-    await b.connect(name=args.name)
+    name = await b.connect(name=args.name)
+    fw = await b.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+    tag = await b.send_lua("print(frame.GIT_TAG)", await_print=True)
+    batt = await b.send_lua("print(frame.battery_level())", await_print=True)
+    print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
     if b.type != BrilliantDeviceType.HALO:
         print("Speaker PCM example is Halo-only")

--- a/python/packages/brilliant_ble/tests/test_taps.py
+++ b/python/packages/brilliant_ble/tests/test_taps.py
@@ -2,13 +2,21 @@
 Tests the Frame specific Lua libraries over Bluetooth.
 """
 import asyncio
+import argparse
 from brilliant_ble import BrilliantBle
 
 
 async def main():
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device over BLE and run this test.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     b = BrilliantBle()
 
-    await b.connect(print_response_handler=lambda s: print(s))
+    await b.connect(name=args.name, print_response_handler=lambda s: print(s))
 
     await b.send_lua("frame.imu.tap_callback((function()print('Tap!')end))")
     print("Waiting for taps... Tap the device to see output. Ctrl+C to stop.")

--- a/python/packages/brilliant_ble/tests/test_taps.py
+++ b/python/packages/brilliant_ble/tests/test_taps.py
@@ -16,7 +16,11 @@ async def main():
     args = parser.parse_args()
     b = BrilliantBle()
 
-    await b.connect(name=args.name, print_response_handler=lambda s: print(s))
+    name = await b.connect(name=args.name, print_response_handler=lambda s: print(s))
+    fw = await b.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+    tag = await b.send_lua("print(frame.GIT_TAG)", await_print=True)
+    batt = await b.send_lua("print(frame.battery_level())", await_print=True)
+    print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
     await b.send_lua("frame.imu.tap_callback((function()print('Tap!')end))")
     print("Waiting for taps... Tap the device to see output. Ctrl+C to stop.")

--- a/python/packages/brilliant_ble/tests/test_text_api.py
+++ b/python/packages/brilliant_ble/tests/test_text_api.py
@@ -1,12 +1,20 @@
 import asyncio
+import argparse
 from brilliant_ble import BrilliantBle
 from brilliant_ble import BrilliantDeviceType
 
 
 async def main():
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device over BLE and run this test.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     b = BrilliantBle()
 
-    await b.connect(print_response_handler=lambda s: print(s))
+    await b.connect(name=args.name, print_response_handler=lambda s: print(s))
 
     if b.type != BrilliantDeviceType.FRAME:
         print("This test is only for Frame devices.")

--- a/python/packages/brilliant_ble/tests/test_text_api.py
+++ b/python/packages/brilliant_ble/tests/test_text_api.py
@@ -14,7 +14,11 @@ async def main():
     args = parser.parse_args()
     b = BrilliantBle()
 
-    await b.connect(name=args.name, print_response_handler=lambda s: print(s))
+    name = await b.connect(name=args.name, print_response_handler=lambda s: print(s))
+    fw = await b.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+    tag = await b.send_lua("print(frame.GIT_TAG)", await_print=True)
+    batt = await b.send_lua("print(frame.battery_level())", await_print=True)
+    print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
     if b.type != BrilliantDeviceType.FRAME:
         print("This test is only for Frame devices.")

--- a/python/packages/brilliant_ble/tests/test_time.py
+++ b/python/packages/brilliant_ble/tests/test_time.py
@@ -1,9 +1,17 @@
 import asyncio
+import argparse
 from brilliant_ble import BrilliantBle
 
 async def main():
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device over BLE and run this test.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     b = BrilliantBle()
-    await b.connect(print_response_handler=lambda s: print(s))
+    await b.connect(name=args.name, print_response_handler=lambda s: print(s))
 
     print("print(frame.time.utc())")
     await b.send_lua("print(frame.time.utc())")

--- a/python/packages/brilliant_ble/tests/test_time.py
+++ b/python/packages/brilliant_ble/tests/test_time.py
@@ -11,7 +11,11 @@ async def main():
     )
     args = parser.parse_args()
     b = BrilliantBle()
-    await b.connect(name=args.name, print_response_handler=lambda s: print(s))
+    name = await b.connect(name=args.name, print_response_handler=lambda s: print(s))
+    fw = await b.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+    tag = await b.send_lua("print(frame.GIT_TAG)", await_print=True)
+    batt = await b.send_lua("print(frame.battery_level())", await_print=True)
+    print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
     print("print(frame.time.utc())")
     await b.send_lua("print(frame.time.utc())")

--- a/python/packages/brilliant_ble/tests/test_version.py
+++ b/python/packages/brilliant_ble/tests/test_version.py
@@ -3,13 +3,21 @@ Tests the Frame specific Lua libraries over Bluetooth.
 """
 
 import asyncio
+import argparse
 from brilliant_ble import BrilliantBle
 
 
 async def main():
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device over BLE and run this test.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     b = BrilliantBle()
 
-    await b.connect(print_response_handler=lambda s: print(s))
+    await b.connect(name=args.name, print_response_handler=lambda s: print(s))
 
     await b.send_lua("print(frame.HARDWARE_VERSION)")
     await b.send_lua("print(frame.FIRMWARE_VERSION)")

--- a/python/packages/brilliant_ble/tests/test_version.py
+++ b/python/packages/brilliant_ble/tests/test_version.py
@@ -17,7 +17,11 @@ async def main():
     args = parser.parse_args()
     b = BrilliantBle()
 
-    await b.connect(name=args.name, print_response_handler=lambda s: print(s))
+    name = await b.connect(name=args.name, print_response_handler=lambda s: print(s))
+    fw = await b.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+    tag = await b.send_lua("print(frame.GIT_TAG)", await_print=True)
+    batt = await b.send_lua("print(frame.battery_level())", await_print=True)
+    print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
     await b.send_lua("print(frame.HARDWARE_VERSION)")
     await b.send_lua("print(frame.FIRMWARE_VERSION)")

--- a/python/packages/brilliant_msg/examples/audio_clip.py
+++ b/python/packages/brilliant_msg/examples/audio_clip.py
@@ -19,7 +19,11 @@ async def main():
     speaker = None
 
     try:
-        await frame.connect(name=args.name)
+        name = await frame.connect(name=args.name)
+        fw = await frame.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+        tag = await frame.send_lua("print(frame.GIT_TAG)", await_print=True)
+        batt = await frame.send_lua("print(frame.battery_level())", await_print=True)
+        print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
         # Let the user know we're starting
         await frame.print_short_text('Loading...')

--- a/python/packages/brilliant_msg/examples/audio_clip.py
+++ b/python/packages/brilliant_msg/examples/audio_clip.py
@@ -1,4 +1,5 @@
 import asyncio
+import argparse
 
 from brilliant_msg import BrilliantMsg, RxAudio, TxCode
 import tempfile
@@ -7,11 +8,18 @@ async def main():
     """
     Subscribe to an Audio stream from Frame and save a short clip as a WAV file
     """
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device and run this example.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     frame = BrilliantMsg()
     speaker = None
 
     try:
-        await frame.connect()
+        await frame.connect(name=args.name)
 
         # Let the user know we're starting
         await frame.print_short_text('Loading...')

--- a/python/packages/brilliant_msg/examples/audio_stream.py
+++ b/python/packages/brilliant_msg/examples/audio_stream.py
@@ -1,4 +1,5 @@
 import asyncio
+import argparse
 import numpy as np
 
 from brilliant_msg import BrilliantMsg, RxAudio, TxCode
@@ -8,6 +9,13 @@ async def main():
     """
     Subscribe to an Audio stream from Frame and play to the default output device using pvspeaker
     """
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device and run this example.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     frame = BrilliantMsg()
     speaker = None
     stop_requested = False
@@ -20,7 +28,7 @@ async def main():
             stop_requested = True
 
     try:
-        await frame.connect()
+        await frame.connect(name=args.name)
         await frame.send_break_signal()
 
         # Let the user know we're starting

--- a/python/packages/brilliant_msg/examples/audio_stream.py
+++ b/python/packages/brilliant_msg/examples/audio_stream.py
@@ -28,7 +28,11 @@ async def main():
             stop_requested = True
 
     try:
-        await frame.connect(name=args.name)
+        name = await frame.connect(name=args.name)
+        fw = await frame.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+        tag = await frame.send_lua("print(frame.GIT_TAG)", await_print=True)
+        batt = await frame.send_lua("print(frame.battery_level())", await_print=True)
+        print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
         await frame.send_break_signal()
 
         # Let the user know we're starting

--- a/python/packages/brilliant_msg/examples/audio_video_stream.py
+++ b/python/packages/brilliant_msg/examples/audio_video_stream.py
@@ -1,4 +1,5 @@
 import asyncio
+import argparse
 import io
 import numpy as np
 from PIL import Image
@@ -12,6 +13,13 @@ async def main():
     """
     Subscribe to an Audio stream from Frame and play to the default output device using pvspeaker, and take periodic photos
     """
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device and run this example.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     frame = BrilliantMsg()
     speaker = None
     stop_requested = False
@@ -24,7 +32,7 @@ async def main():
             stop_requested = True
 
     try:
-        await frame.connect()
+        await frame.connect(name=args.name)
 
         # Let the user know we're starting
         await frame.print_short_text('Loading...')

--- a/python/packages/brilliant_msg/examples/audio_video_stream.py
+++ b/python/packages/brilliant_msg/examples/audio_video_stream.py
@@ -32,7 +32,11 @@ async def main():
             stop_requested = True
 
     try:
-        await frame.connect(name=args.name)
+        name = await frame.connect(name=args.name)
+        fw = await frame.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+        tag = await frame.send_lua("print(frame.GIT_TAG)", await_print=True)
+        batt = await frame.send_lua("print(frame.battery_level())", await_print=True)
+        print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
         # Let the user know we're starting
         await frame.print_short_text('Loading...')

--- a/python/packages/brilliant_msg/examples/auto_exposure.py
+++ b/python/packages/brilliant_msg/examples/auto_exposure.py
@@ -20,7 +20,11 @@ async def main():
     args = parser.parse_args()
     frame = BrilliantMsg()
     try:
-        await frame.connect(name=args.name)
+        name = await frame.connect(name=args.name)
+        fw = await frame.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+        tag = await frame.send_lua("print(frame.GIT_TAG)", await_print=True)
+        batt = await frame.send_lua("print(frame.battery_level())", await_print=True)
+        print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
         if frame.type != BrilliantDeviceType.FRAME:
             print("Auto exposure is a Frame-only feature")

--- a/python/packages/brilliant_msg/examples/auto_exposure.py
+++ b/python/packages/brilliant_msg/examples/auto_exposure.py
@@ -1,4 +1,5 @@
 import asyncio
+import argparse
 from PIL import Image
 import io
 
@@ -10,9 +11,16 @@ async def main():
     Run the autoexposure algorithm on Frame repeatedly and print the changing values to the console
     along with a photo taken at each step.
     """
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device and run this example.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     frame = BrilliantMsg()
     try:
-        await frame.connect()
+        await frame.connect(name=args.name)
 
         if frame.type != BrilliantDeviceType.FRAME:
             print("Auto exposure is a Frame-only feature")

--- a/python/packages/brilliant_msg/examples/camera.py
+++ b/python/packages/brilliant_msg/examples/camera.py
@@ -19,7 +19,11 @@ async def main():
     args = parser.parse_args()
     frame = BrilliantMsg()
     try:
-        await frame.connect(name=args.name)
+        name = await frame.connect(name=args.name)
+        fw = await frame.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+        tag = await frame.send_lua("print(frame.GIT_TAG)", await_print=True)
+        batt = await frame.send_lua("print(frame.battery_level())", await_print=True)
+        print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
         # debug only: check our current battery level and memory usage (which varies between 16kb and 31kb or so even after the VM init)
         batt_mem = await frame.send_lua('print(frame.battery_level() .. " / " .. collectgarbage("count"))', await_print=True)

--- a/python/packages/brilliant_msg/examples/camera.py
+++ b/python/packages/brilliant_msg/examples/camera.py
@@ -1,4 +1,5 @@
 import asyncio
+import argparse
 from PIL import Image
 import io
 
@@ -9,9 +10,16 @@ async def main():
     """
     Take a photo using the Frame camera and display it in the system viewer
     """
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device and run this example.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     frame = BrilliantMsg()
     try:
-        await frame.connect()
+        await frame.connect(name=args.name)
 
         # debug only: check our current battery level and memory usage (which varies between 16kb and 31kb or so even after the VM init)
         batt_mem = await frame.send_lua('print(frame.battery_level() .. " / " .. collectgarbage("count"))', await_print=True)

--- a/python/packages/brilliant_msg/examples/camera_extras.py
+++ b/python/packages/brilliant_msg/examples/camera_extras.py
@@ -17,7 +17,11 @@ async def main():
     args = parser.parse_args()
     frame = BrilliantMsg()
     try:
-        await frame.connect(name=args.name)
+        name = await frame.connect(name=args.name)
+        fw = await frame.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+        tag = await frame.send_lua("print(frame.GIT_TAG)", await_print=True)
+        batt = await frame.send_lua("print(frame.battery_level())", await_print=True)
+        print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
         # Send the main lua application from this project to Frame that will run the app
         await frame.upload_frame_app(local_filename="lua/camera_extras_frame_app.lua")

--- a/python/packages/brilliant_msg/examples/camera_extras.py
+++ b/python/packages/brilliant_msg/examples/camera_extras.py
@@ -1,4 +1,5 @@
 import asyncio
+import argparse
 import io
 import traceback
 from PIL import Image
@@ -7,9 +8,16 @@ from brilliant_ble import BrilliantDeviceType
 from brilliant_msg import BrilliantMsg, RxPhoto
 
 async def main():
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device and run this example.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     frame = BrilliantMsg()
     try:
-        await frame.connect()
+        await frame.connect(name=args.name)
 
         # Send the main lua application from this project to Frame that will run the app
         await frame.upload_frame_app(local_filename="lua/camera_extras_frame_app.lua")

--- a/python/packages/brilliant_msg/examples/camera_sprite.py
+++ b/python/packages/brilliant_msg/examples/camera_sprite.py
@@ -17,7 +17,11 @@ async def main():
     args = parser.parse_args()
     frame = BrilliantMsg()
     try:
-        await frame.connect(name=args.name)
+        name = await frame.connect(name=args.name)
+        fw = await frame.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+        tag = await frame.send_lua("print(frame.GIT_TAG)", await_print=True)
+        batt = await frame.send_lua("print(frame.battery_level())", await_print=True)
+        print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
         # debug only: check our current battery level and memory usage (which varies between 16kb and 31kb or so even after the VM init)
         batt_mem = await frame.send_lua('print(frame.battery_level() .. " / " .. collectgarbage("count"))', await_print=True)

--- a/python/packages/brilliant_msg/examples/camera_sprite.py
+++ b/python/packages/brilliant_msg/examples/camera_sprite.py
@@ -1,4 +1,5 @@
 import asyncio
+import argparse
 
 from brilliant_msg import BrilliantMsg, RxPhoto, TxCaptureSettings, TxSprite, TxImageSpriteBlock
 from brilliant_ble import BrilliantDeviceType
@@ -7,9 +8,16 @@ async def main():
     """
     Take a photo using the Frame camera and display it on the Frame display
     """
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device and run this example.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     frame = BrilliantMsg()
     try:
-        await frame.connect()
+        await frame.connect(name=args.name)
 
         # debug only: check our current battery level and memory usage (which varies between 16kb and 31kb or so even after the VM init)
         batt_mem = await frame.send_lua('print(frame.battery_level() .. " / " .. collectgarbage("count"))', await_print=True)

--- a/python/packages/brilliant_msg/examples/camera_sprite_loop.py
+++ b/python/packages/brilliant_msg/examples/camera_sprite_loop.py
@@ -1,4 +1,5 @@
 import asyncio
+import argparse
 from PIL import Image
 import io
 import numpy as np
@@ -10,9 +11,16 @@ async def main():
     """
     Repeatedly take photos using the Frame camera and display them on the Frame display
     """
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device and run this example.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     frame = BrilliantMsg()
     try:
-        await frame.connect()
+        await frame.connect(name=args.name)
 
         # debug only: check our current battery level and memory usage (which varies between 16kb and 31kb or so even after the VM init)
         batt_mem = await frame.send_lua('print(frame.battery_level() .. " / " .. collectgarbage("count"))', await_print=True)

--- a/python/packages/brilliant_msg/examples/camera_sprite_loop.py
+++ b/python/packages/brilliant_msg/examples/camera_sprite_loop.py
@@ -20,7 +20,11 @@ async def main():
     args = parser.parse_args()
     frame = BrilliantMsg()
     try:
-        await frame.connect(name=args.name)
+        name = await frame.connect(name=args.name)
+        fw = await frame.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+        tag = await frame.send_lua("print(frame.GIT_TAG)", await_print=True)
+        batt = await frame.send_lua("print(frame.battery_level())", await_print=True)
+        print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
         # debug only: check our current battery level and memory usage (which varies between 16kb and 31kb or so even after the VM init)
         batt_mem = await frame.send_lua('print(frame.battery_level() .. " / " .. collectgarbage("count"))', await_print=True)

--- a/python/packages/brilliant_msg/examples/code_value.py
+++ b/python/packages/brilliant_msg/examples/code_value.py
@@ -1,4 +1,5 @@
 import asyncio
+import argparse
 
 from brilliant_msg import BrilliantMsg, TxCode
 
@@ -6,9 +7,16 @@ async def main():
     """
     Send a tiny TxCode message to Frame with a single-byte value as a control message
     """
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device and run this example.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     frame = BrilliantMsg()
     try:
-        await frame.connect()
+        await frame.connect(name=args.name)
 
         # debug only: check our current battery level and memory usage (which varies between 16kb and 31kb or so even after the VM init)
         batt_mem = await frame.send_lua('print(frame.battery_level() .. " / " .. collectgarbage("count"))', await_print=True)

--- a/python/packages/brilliant_msg/examples/code_value.py
+++ b/python/packages/brilliant_msg/examples/code_value.py
@@ -16,7 +16,11 @@ async def main():
     args = parser.parse_args()
     frame = BrilliantMsg()
     try:
-        await frame.connect(name=args.name)
+        name = await frame.connect(name=args.name)
+        fw = await frame.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+        tag = await frame.send_lua("print(frame.GIT_TAG)", await_print=True)
+        batt = await frame.send_lua("print(frame.battery_level())", await_print=True)
+        print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
         # debug only: check our current battery level and memory usage (which varies between 16kb and 31kb or so even after the VM init)
         batt_mem = await frame.send_lua('print(frame.battery_level() .. " / " .. collectgarbage("count"))', await_print=True)

--- a/python/packages/brilliant_msg/examples/compress_decompress.py
+++ b/python/packages/brilliant_msg/examples/compress_decompress.py
@@ -1,12 +1,20 @@
 import asyncio
+import argparse
 from brilliant_ble import BrilliantBle
 import lz4.frame
 
 async def main():
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device and run this example.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     frame = BrilliantBle()
 
     try:
-        await frame.connect()
+        await frame.connect(name=args.name)
 
         lua_script = """
             function decomp_func(data)

--- a/python/packages/brilliant_msg/examples/compress_decompress.py
+++ b/python/packages/brilliant_msg/examples/compress_decompress.py
@@ -14,7 +14,11 @@ async def main():
     frame = BrilliantBle()
 
     try:
-        await frame.connect(name=args.name)
+        name = await frame.connect(name=args.name)
+        fw = await frame.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+        tag = await frame.send_lua("print(frame.GIT_TAG)", await_print=True)
+        batt = await frame.send_lua("print(frame.battery_level())", await_print=True)
+        print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
         lua_script = """
             function decomp_func(data)

--- a/python/packages/brilliant_msg/examples/compressed_sprite_ind_png.py
+++ b/python/packages/brilliant_msg/examples/compressed_sprite_ind_png.py
@@ -1,4 +1,5 @@
 import asyncio
+import argparse
 from pathlib import Path
 
 from brilliant_msg import BrilliantMsg, TxSprite, TxImageSpriteBlock
@@ -27,9 +28,16 @@ async def main():
     palettes of other colors, the frameside app must call `sprite.set_palette()` (which lua/sprite_frame_app.lua does)
     or call the underlying `frame.display.assign_color()` before the `frame.display.bitmap()` call.
     """
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device and run this example.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     frame = BrilliantMsg()
     try:
-        await frame.connect()
+        await frame.connect(name=args.name)
 
         # Let the user know we're starting
         await frame.print_short_text('Loading...')

--- a/python/packages/brilliant_msg/examples/compressed_sprite_ind_png.py
+++ b/python/packages/brilliant_msg/examples/compressed_sprite_ind_png.py
@@ -37,7 +37,11 @@ async def main():
     args = parser.parse_args()
     frame = BrilliantMsg()
     try:
-        await frame.connect(name=args.name)
+        name = await frame.connect(name=args.name)
+        fw = await frame.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+        tag = await frame.send_lua("print(frame.GIT_TAG)", await_print=True)
+        batt = await frame.send_lua("print(frame.battery_level())", await_print=True)
+        print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
         # Let the user know we're starting
         await frame.print_short_text('Loading...')

--- a/python/packages/brilliant_msg/examples/imu.py
+++ b/python/packages/brilliant_msg/examples/imu.py
@@ -1,4 +1,5 @@
 import asyncio
+import argparse
 
 from brilliant_msg import BrilliantMsg, RxIMU, TxCode
 
@@ -6,9 +7,16 @@ async def main():
     """
     Subscribe to IMU updates from Frame and print them to the console
     """
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device and run this example.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     frame = BrilliantMsg()
     try:
-        await frame.connect()
+        await frame.connect(name=args.name)
 
         # Let the user know we're starting
         await frame.print_short_text('Loading...')

--- a/python/packages/brilliant_msg/examples/imu.py
+++ b/python/packages/brilliant_msg/examples/imu.py
@@ -16,7 +16,11 @@ async def main():
     args = parser.parse_args()
     frame = BrilliantMsg()
     try:
-        await frame.connect(name=args.name)
+        name = await frame.connect(name=args.name)
+        fw = await frame.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+        tag = await frame.send_lua("print(frame.GIT_TAG)", await_print=True)
+        batt = await frame.send_lua("print(frame.battery_level())", await_print=True)
+        print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
         # Let the user know we're starting
         await frame.print_short_text('Loading...')

--- a/python/packages/brilliant_msg/examples/layout.py
+++ b/python/packages/brilliant_msg/examples/layout.py
@@ -1,4 +1,5 @@
 import asyncio
+import argparse
 
 from brilliant_msg import BrilliantMsg, TxCode, TxTextSpriteBlock
 from brilliant_ble import BrilliantDeviceType
@@ -7,10 +8,17 @@ async def main():
     """
     Use a simple layout engine to draw in separate regions of the display
     """
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device and run this example.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     frame = BrilliantMsg()
 
     try:
-        await frame.connect()
+        await frame.connect(name=args.name)
 
         if frame.type != BrilliantDeviceType.HALO:
             print("layout example is Halo-only")

--- a/python/packages/brilliant_msg/examples/layout.py
+++ b/python/packages/brilliant_msg/examples/layout.py
@@ -18,7 +18,11 @@ async def main():
     frame = BrilliantMsg()
 
     try:
-        await frame.connect(name=args.name)
+        name = await frame.connect(name=args.name)
+        fw = await frame.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+        tag = await frame.send_lua("print(frame.GIT_TAG)", await_print=True)
+        batt = await frame.send_lua("print(frame.battery_level())", await_print=True)
+        print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
         if frame.type != BrilliantDeviceType.HALO:
             print("layout example is Halo-only")

--- a/python/packages/brilliant_msg/examples/live_camera_feed.py
+++ b/python/packages/brilliant_msg/examples/live_camera_feed.py
@@ -28,7 +28,11 @@ async def main():
         cv2.namedWindow(window_name, cv2.WINDOW_NORMAL)
         
         frame = BrilliantMsg()
-        await frame.connect(name=args.name)
+        name = await frame.connect(name=args.name)
+        fw = await frame.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+        tag = await frame.send_lua("print(frame.GIT_TAG)", await_print=True)
+        batt = await frame.send_lua("print(frame.battery_level())", await_print=True)
+        print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
         # debug only: check our current battery level and memory usage
         batt_mem = await frame.send_lua('print(frame.battery_level() .. " / " .. collectgarbage("count"))', await_print=True)

--- a/python/packages/brilliant_msg/examples/live_camera_feed.py
+++ b/python/packages/brilliant_msg/examples/live_camera_feed.py
@@ -1,4 +1,5 @@
 import asyncio
+import argparse
 from PIL import Image
 import io
 import cv2
@@ -11,6 +12,13 @@ async def main():
     """
     Take photos continuously using the Frame camera and display them in an OpenCV window
     """
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device and run this example.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     frame = None
     rx_photo = None
     window_name = "Camera Feed"
@@ -20,7 +28,7 @@ async def main():
         cv2.namedWindow(window_name, cv2.WINDOW_NORMAL)
         
         frame = BrilliantMsg()
-        await frame.connect()
+        await frame.connect(name=args.name)
 
         # debug only: check our current battery level and memory usage
         batt_mem = await frame.send_lua('print(frame.battery_level() .. " / " .. collectgarbage("count"))', await_print=True)

--- a/python/packages/brilliant_msg/examples/live_camera_feed_with_params.py
+++ b/python/packages/brilliant_msg/examples/live_camera_feed_with_params.py
@@ -171,7 +171,11 @@ async def main(display):
 
     try:
         frame = BrilliantMsg()
-        await frame.connect(name=args.name)
+        name = await frame.connect(name=args.name)
+        fw = await frame.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+        tag = await frame.send_lua("print(frame.GIT_TAG)", await_print=True)
+        batt = await frame.send_lua("print(frame.battery_level())", await_print=True)
+        print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
         if frame.type != BrilliantDeviceType.FRAME:
             print("Live camera feed with parameters is a Frame-only feature")

--- a/python/packages/brilliant_msg/examples/live_camera_feed_with_params.py
+++ b/python/packages/brilliant_msg/examples/live_camera_feed_with_params.py
@@ -1,4 +1,5 @@
 import asyncio
+import argparse
 from PIL import Image
 import io
 import cv2
@@ -157,13 +158,20 @@ async def main(display):
     """
     Take photos continuously using the Frame camera and display them with auto-exposure parameters
     """
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device and run this example.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     frame = None
     rx_photo = None
     rx_autoexp = None
 
     try:
         frame = BrilliantMsg()
-        await frame.connect()
+        await frame.connect(name=args.name)
 
         if frame.type != BrilliantDeviceType.FRAME:
             print("Live camera feed with parameters is a Frame-only feature")

--- a/python/packages/brilliant_msg/examples/manual_exposure.py
+++ b/python/packages/brilliant_msg/examples/manual_exposure.py
@@ -1,4 +1,5 @@
 import asyncio
+import argparse
 from PIL import Image
 import io
 
@@ -8,9 +9,16 @@ async def main():
     """
     Set camera exposure settings manually and take a single photo
     """
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device and run this example.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     frame = BrilliantMsg()
     try:
-        await frame.connect()
+        await frame.connect(name=args.name)
 
         if frame.type != BrilliantDeviceType.FRAME:
             print("Manual exposure is a Frame-only feature")

--- a/python/packages/brilliant_msg/examples/manual_exposure.py
+++ b/python/packages/brilliant_msg/examples/manual_exposure.py
@@ -18,7 +18,11 @@ async def main():
     args = parser.parse_args()
     frame = BrilliantMsg()
     try:
-        await frame.connect(name=args.name)
+        name = await frame.connect(name=args.name)
+        fw = await frame.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+        tag = await frame.send_lua("print(frame.GIT_TAG)", await_print=True)
+        batt = await frame.send_lua("print(frame.battery_level())", await_print=True)
+        print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
         if frame.type != BrilliantDeviceType.FRAME:
             print("Manual exposure is a Frame-only feature")

--- a/python/packages/brilliant_msg/examples/metering.py
+++ b/python/packages/brilliant_msg/examples/metering.py
@@ -1,4 +1,5 @@
 import asyncio
+import argparse
 
 from brilliant_msg import BrilliantMsg, TxCode, RxMeteringData
 from brilliant_ble import BrilliantDeviceType
@@ -7,9 +8,16 @@ async def main():
     """
     Query the metering data on Frame repeatedly and print the changing values to the console
     """
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device and run this example.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     frame = BrilliantMsg()
     try:
-        await frame.connect()
+        await frame.connect(name=args.name)
 
         if frame.type != BrilliantDeviceType.FRAME:
             print("Metering data is a Frame-only feature")

--- a/python/packages/brilliant_msg/examples/metering.py
+++ b/python/packages/brilliant_msg/examples/metering.py
@@ -17,7 +17,11 @@ async def main():
     args = parser.parse_args()
     frame = BrilliantMsg()
     try:
-        await frame.connect(name=args.name)
+        name = await frame.connect(name=args.name)
+        fw = await frame.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+        tag = await frame.send_lua("print(frame.GIT_TAG)", await_print=True)
+        batt = await frame.send_lua("print(frame.battery_level())", await_print=True)
+        print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
         if frame.type != BrilliantDeviceType.FRAME:
             print("Metering data is a Frame-only feature")

--- a/python/packages/brilliant_msg/examples/multi_tap.py
+++ b/python/packages/brilliant_msg/examples/multi_tap.py
@@ -16,7 +16,11 @@ async def main():
     args = parser.parse_args()
     frame = BrilliantMsg()
     try:
-        await frame.connect(name=args.name)
+        name = await frame.connect(name=args.name)
+        fw = await frame.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+        tag = await frame.send_lua("print(frame.GIT_TAG)", await_print=True)
+        batt = await frame.send_lua("print(frame.battery_level())", await_print=True)
+        print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
         # Let the user know we're starting
         await frame.print_short_text('Loading...')

--- a/python/packages/brilliant_msg/examples/multi_tap.py
+++ b/python/packages/brilliant_msg/examples/multi_tap.py
@@ -1,4 +1,5 @@
 import asyncio
+import argparse
 
 from brilliant_msg import BrilliantMsg, RxTap, TxCode
 
@@ -6,9 +7,16 @@ async def main():
     """
     Register multi-taps from Frame and print them to the console
     """
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device and run this example.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     frame = BrilliantMsg()
     try:
-        await frame.connect()
+        await frame.connect(name=args.name)
 
         # Let the user know we're starting
         await frame.print_short_text('Loading...')

--- a/python/packages/brilliant_msg/examples/openai_realtime.py
+++ b/python/packages/brilliant_msg/examples/openai_realtime.py
@@ -511,12 +511,16 @@ async def main():
     frame = BrilliantMsg()
     started_audio = False
     try:
-        await frame.connect(name=args.name)
+        name = await frame.connect(name=args.name)
         if frame.type != BrilliantDeviceType.HALO:
             print("This example requires a Halo (LC3 audio in both directions)")
             return
 
         await frame.send_break_signal()
+        fw = await frame.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+        tag = await frame.send_lua("print(frame.GIT_TAG)", await_print=True)
+        batt = await frame.send_lua("print(frame.battery_level())", await_print=True)
+        print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
         await frame.print_short_text("Connecting...")
         await frame.upload_stdlua_libs(lib_names=["data", "code", "plain_text"])
         lua_path = os.path.join(os.path.dirname(__file__), "lua",

--- a/python/packages/brilliant_msg/examples/plain_text.py
+++ b/python/packages/brilliant_msg/examples/plain_text.py
@@ -1,4 +1,5 @@
 import asyncio
+import argparse
 
 from brilliant_msg import BrilliantMsg, TxPlainText
 
@@ -6,9 +7,16 @@ async def main():
     """
     Print Plain Text on Frame's display using TxPlainText message
     """
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device and run this example.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     frame = BrilliantMsg()
     try:
-        await frame.connect()
+        await frame.connect(name=args.name)
 
         # debug only: check our current battery level and memory usage (which varies between 16kb and 31kb or so even after the VM init)
         batt_mem = await frame.send_lua('print(frame.battery_level() .. " / " .. collectgarbage("count"))', await_print=True)

--- a/python/packages/brilliant_msg/examples/plain_text.py
+++ b/python/packages/brilliant_msg/examples/plain_text.py
@@ -16,7 +16,11 @@ async def main():
     args = parser.parse_args()
     frame = BrilliantMsg()
     try:
-        await frame.connect(name=args.name)
+        name = await frame.connect(name=args.name)
+        fw = await frame.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+        tag = await frame.send_lua("print(frame.GIT_TAG)", await_print=True)
+        batt = await frame.send_lua("print(frame.battery_level())", await_print=True)
+        print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
         # debug only: check our current battery level and memory usage (which varies between 16kb and 31kb or so even after the VM init)
         batt_mem = await frame.send_lua('print(frame.battery_level() .. " / " .. collectgarbage("count"))', await_print=True)

--- a/python/packages/brilliant_msg/examples/prog_sprite_jpg.py
+++ b/python/packages/brilliant_msg/examples/prog_sprite_jpg.py
@@ -25,7 +25,11 @@ async def main():
     args = parser.parse_args()
     frame = BrilliantMsg()
     try:
-        await frame.connect(name=args.name)
+        name = await frame.connect(name=args.name)
+        fw = await frame.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+        tag = await frame.send_lua("print(frame.GIT_TAG)", await_print=True)
+        batt = await frame.send_lua("print(frame.battery_level())", await_print=True)
+        print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
         # debug only: check our current battery level and memory usage (which varies between 16kb and 31kb or so even after the VM init)
         batt_mem = await frame.send_lua('print(frame.battery_level() .. " / " .. collectgarbage("count"))', await_print=True)

--- a/python/packages/brilliant_msg/examples/prog_sprite_jpg.py
+++ b/python/packages/brilliant_msg/examples/prog_sprite_jpg.py
@@ -1,4 +1,5 @@
 import asyncio
+import argparse
 from pathlib import Path
 
 from brilliant_msg import BrilliantMsg, TxSprite, TxImageSpriteBlock
@@ -15,9 +16,16 @@ async def main():
     This will not be the standard palette from the Frame firmware so the frameside app
     (lua/sprite_frame_app.lua) calls `sprite.set_palette()` before the `frame.display.bitmap()` call.
     """
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device and run this example.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     frame = BrilliantMsg()
     try:
-        await frame.connect()
+        await frame.connect(name=args.name)
 
         # debug only: check our current battery level and memory usage (which varies between 16kb and 31kb or so even after the VM init)
         batt_mem = await frame.send_lua('print(frame.battery_level() .. " / " .. collectgarbage("count"))', await_print=True)

--- a/python/packages/brilliant_msg/examples/sound_effects.py
+++ b/python/packages/brilliant_msg/examples/sound_effects.py
@@ -31,7 +31,11 @@ async def main():
     args = parser.parse_args()
     frame = BrilliantMsg()
     try:
-        await frame.connect(name=args.name)
+        name = await frame.connect(name=args.name)
+        fw = await frame.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+        tag = await frame.send_lua("print(frame.GIT_TAG)", await_print=True)
+        batt = await frame.send_lua("print(frame.battery_level())", await_print=True)
+        print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
         if frame.type != BrilliantDeviceType.HALO:
             print("Speaker is a Halo-only feature")

--- a/python/packages/brilliant_msg/examples/sound_effects.py
+++ b/python/packages/brilliant_msg/examples/sound_effects.py
@@ -1,4 +1,5 @@
 import asyncio
+import argparse
 import random
 import traceback
 
@@ -21,9 +22,16 @@ async def main():
     Each sound is generated from a preset name and a 32-bit seed, so the same
     seed always reproduces the same sound.
     """
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device and run this example.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     frame = BrilliantMsg()
     try:
-        await frame.connect()
+        await frame.connect(name=args.name)
 
         if frame.type != BrilliantDeviceType.HALO:
             print("Speaker is a Halo-only feature")

--- a/python/packages/brilliant_msg/examples/speaker_lc3.py
+++ b/python/packages/brilliant_msg/examples/speaker_lc3.py
@@ -1,4 +1,5 @@
 import asyncio
+import argparse
 
 from brilliant_msg import BrilliantMsg, TxCode
 from brilliant_ble import BrilliantDeviceType
@@ -7,9 +8,16 @@ async def main():
     """
     Play an LC3 file on the Halo speakers
     """
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device and run this example.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     frame = BrilliantMsg()
     try:
-        await frame.connect()
+        await frame.connect(name=args.name)
 
         if frame.type != BrilliantDeviceType.HALO:
             print("Speaker is a Halo-only feature")

--- a/python/packages/brilliant_msg/examples/speaker_lc3.py
+++ b/python/packages/brilliant_msg/examples/speaker_lc3.py
@@ -17,7 +17,11 @@ async def main():
     args = parser.parse_args()
     frame = BrilliantMsg()
     try:
-        await frame.connect(name=args.name)
+        name = await frame.connect(name=args.name)
+        fw = await frame.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+        tag = await frame.send_lua("print(frame.GIT_TAG)", await_print=True)
+        batt = await frame.send_lua("print(frame.battery_level())", await_print=True)
+        print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
         if frame.type != BrilliantDeviceType.HALO:
             print("Speaker is a Halo-only feature")

--- a/python/packages/brilliant_msg/examples/sprite_ind_png.py
+++ b/python/packages/brilliant_msg/examples/sprite_ind_png.py
@@ -1,4 +1,5 @@
 import asyncio
+import argparse
 from pathlib import Path
 
 from brilliant_msg import BrilliantMsg, TxSprite
@@ -13,9 +14,16 @@ async def main():
     palettes of other colors, the frameside app must call `sprite.set_palette()` (which lua/sprite_frame_app.lua does)
     or call the underlying `frame.display.assign_color()` before the `frame.display.bitmap()` call.
     """
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device and run this example.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     frame = BrilliantMsg()
     try:
-        await frame.connect()
+        await frame.connect(name=args.name)
 
         # debug only: check our current battery level and memory usage (which varies between 16kb and 31kb or so even after the VM init)
         batt_mem = await frame.send_lua('print(frame.battery_level() .. " / " .. collectgarbage("count"))', await_print=True)

--- a/python/packages/brilliant_msg/examples/sprite_ind_png.py
+++ b/python/packages/brilliant_msg/examples/sprite_ind_png.py
@@ -23,7 +23,11 @@ async def main():
     args = parser.parse_args()
     frame = BrilliantMsg()
     try:
-        await frame.connect(name=args.name)
+        name = await frame.connect(name=args.name)
+        fw = await frame.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+        tag = await frame.send_lua("print(frame.GIT_TAG)", await_print=True)
+        batt = await frame.send_lua("print(frame.battery_level())", await_print=True)
+        print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
         # debug only: check our current battery level and memory usage (which varies between 16kb and 31kb or so even after the VM init)
         batt_mem = await frame.send_lua('print(frame.battery_level() .. " / " .. collectgarbage("count"))', await_print=True)

--- a/python/packages/brilliant_msg/examples/sprite_jpg.py
+++ b/python/packages/brilliant_msg/examples/sprite_jpg.py
@@ -23,7 +23,11 @@ async def main():
     args = parser.parse_args()
     frame = BrilliantMsg()
     try:
-        await frame.connect(name=args.name)
+        name = await frame.connect(name=args.name)
+        fw = await frame.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+        tag = await frame.send_lua("print(frame.GIT_TAG)", await_print=True)
+        batt = await frame.send_lua("print(frame.battery_level())", await_print=True)
+        print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
         # debug only: check our current battery level and memory usage (which varies between 16kb and 31kb or so even after the VM init)
         batt_mem = await frame.send_lua('print(frame.battery_level() .. " / " .. collectgarbage("count"))', await_print=True)

--- a/python/packages/brilliant_msg/examples/sprite_jpg.py
+++ b/python/packages/brilliant_msg/examples/sprite_jpg.py
@@ -1,4 +1,5 @@
 import asyncio
+import argparse
 from pathlib import Path
 
 from brilliant_msg import BrilliantMsg, TxSprite
@@ -13,9 +14,16 @@ async def main():
     This will not be the standard palette from the Frame firmware so the frameside app
     (lua/sprite_frame_app.lua) calls `sprite.set_palette()` before the `frame.display.bitmap()` call.
     """
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device and run this example.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     frame = BrilliantMsg()
     try:
-        await frame.connect()
+        await frame.connect(name=args.name)
 
         # debug only: check our current battery level and memory usage (which varies between 16kb and 31kb or so even after the VM init)
         batt_mem = await frame.send_lua('print(frame.battery_level() .. " / " .. collectgarbage("count"))', await_print=True)

--- a/python/packages/brilliant_msg/examples/sprite_move.py
+++ b/python/packages/brilliant_msg/examples/sprite_move.py
@@ -1,4 +1,5 @@
 import asyncio
+import argparse
 from pathlib import Path
 from random import randint
 
@@ -10,9 +11,16 @@ async def main():
 
     The sprite is a 1-bit indexed PNG image.
     """
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device and run this example.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     frame = BrilliantMsg()
     try:
-        await frame.connect()
+        await frame.connect(name=args.name)
 
         # debug only: check our current battery level and memory usage (which varies between 16kb and 31kb or so even after the VM init)
         batt_mem = await frame.send_lua('print(frame.battery_level() .. " / " .. collectgarbage("count"))', await_print=True)

--- a/python/packages/brilliant_msg/examples/sprite_move.py
+++ b/python/packages/brilliant_msg/examples/sprite_move.py
@@ -20,7 +20,11 @@ async def main():
     args = parser.parse_args()
     frame = BrilliantMsg()
     try:
-        await frame.connect(name=args.name)
+        name = await frame.connect(name=args.name)
+        fw = await frame.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+        tag = await frame.send_lua("print(frame.GIT_TAG)", await_print=True)
+        batt = await frame.send_lua("print(frame.battery_level())", await_print=True)
+        print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
         # debug only: check our current battery level and memory usage (which varies between 16kb and 31kb or so even after the VM init)
         batt_mem = await frame.send_lua('print(frame.battery_level() .. " / " .. collectgarbage("count"))', await_print=True)

--- a/python/packages/brilliant_msg/examples/text_sprite_block.py
+++ b/python/packages/brilliant_msg/examples/text_sprite_block.py
@@ -1,4 +1,5 @@
 import asyncio
+import argparse
 
 from brilliant_msg import BrilliantMsg, TxCode, TxTextSpriteBlock
 
@@ -6,9 +7,16 @@ async def main():
     """
     Print rasterized text with a user-specified font on Frame's display using TxTextSpriteBlock
     """
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device and run this example.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     frame = BrilliantMsg()
     try:
-        await frame.connect()
+        await frame.connect(name=args.name)
 
         # debug only: check our current battery level and memory usage (which varies between 16kb and 31kb or so even after the VM init)
         batt_mem = await frame.ble.send_lua('print(frame.battery_level() .. " / " .. collectgarbage("count"))', await_print=True)

--- a/python/packages/brilliant_msg/examples/text_sprite_block.py
+++ b/python/packages/brilliant_msg/examples/text_sprite_block.py
@@ -16,7 +16,11 @@ async def main():
     args = parser.parse_args()
     frame = BrilliantMsg()
     try:
-        await frame.connect(name=args.name)
+        name = await frame.connect(name=args.name)
+        fw = await frame.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+        tag = await frame.send_lua("print(frame.GIT_TAG)", await_print=True)
+        batt = await frame.send_lua("print(frame.battery_level())", await_print=True)
+        print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
         # debug only: check our current battery level and memory usage (which varies between 16kb and 31kb or so even after the VM init)
         batt_mem = await frame.ble.send_lua('print(frame.battery_level() .. " / " .. collectgarbage("count"))', await_print=True)

--- a/python/packages/brilliant_msg/examples/wake_on_audio.py
+++ b/python/packages/brilliant_msg/examples/wake_on_audio.py
@@ -1,4 +1,5 @@
 import asyncio
+import argparse
 import traceback
 
 from brilliant_msg import BrilliantMsg, RxAudio, TxCode
@@ -11,11 +12,18 @@ async def main():
     Subscribe to an Audio stream from Halo upon wake from Audio Activity Detection (AAD) 
     and save a short clip as a WAV file
     """
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device and run this example.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
     frame = BrilliantMsg()
     speaker = None
 
     try:
-        await frame.connect()
+        await frame.connect(name=args.name)
 
         if frame.type != BrilliantDeviceType.HALO:
             print("Wake-on-audio is a Halo-only feature")

--- a/python/packages/brilliant_msg/examples/wake_on_audio.py
+++ b/python/packages/brilliant_msg/examples/wake_on_audio.py
@@ -23,7 +23,11 @@ async def main():
     speaker = None
 
     try:
-        await frame.connect(name=args.name)
+        name = await frame.connect(name=args.name)
+        fw = await frame.send_lua("print(frame.FIRMWARE_VERSION)", await_print=True)
+        tag = await frame.send_lua("print(frame.GIT_TAG)", await_print=True)
+        batt = await frame.send_lua("print(frame.battery_level())", await_print=True)
+        print(f"{name} | firmware {fw} | git {tag} | battery {batt}%")
 
         if frame.type != BrilliantDeviceType.HALO:
             print("Wake-on-audio is a Halo-only feature")

--- a/python/packages/brilliant_msg/src/brilliant_msg/brilliant_msg.py
+++ b/python/packages/brilliant_msg/src/brilliant_msg/brilliant_msg.py
@@ -27,13 +27,14 @@ class BrilliantMsg:
                              first Halo/Frame discovered.
 
         Returns:
-            bool: True if connection and initialization were successful
+            str: The BLE local name of the connected device (e.g. "Halo 08"),
+                 also available afterwards as `self.name`.
 
         Raises:
             Any exceptions from the underlying BrilliantBle connection
         """
         try:
-            await self.ble.connect(name=name, data_response_handler=self._handle_data_response)
+            device_name = await self.ble.connect(name=name, data_response_handler=self._handle_data_response)
 
             if initialize:
                 # Send break signal in case an application loop is running
@@ -45,7 +46,7 @@ class BrilliantMsg:
                 # Another break signal in case of auto-starting main.lua
                 await self.ble.send_break_signal()
 
-            return True
+            return device_name
 
         except Exception as e:
             # If anything fails during connection or initialization,


### PR DESCRIPTION
Brings the `brilliant_ble` and `brilliant_msg` Python examples and manual hardware-test scripts up to a single standard. Some scripts already used argparse, allowed device selection by name, and printed diagnostics on connect; most did not. This applies each fix consistently, one fix-type per commit for easy review.

## What changed

**1. argparse + `--name` device selection** (`51cec7b`)
Every runnable example and manual hardware-test script that lacked it now has a consistent argparse block with a `--name` argument threaded into `connect()`, so any script can target a specific device (e.g. `--name "Halo 08"`) instead of only the nearest. No behaviour change when run without `--name`. Matches the pattern already used by `ota_flash.py` and the firmware test scripts.

**2. Connection diagnostics** (`b9f633b`)
After connecting, each script prints one line: `name | firmware <fw> | git <tag> | battery <batt>%`, matching the firmware test scripts. Library support:
- `BrilliantBle` now stores the connected BLE local name and exposes it via a read-only `.name` property (previously only returned from `connect()`).
- `BrilliantMsg.connect()` now returns the device name instead of `True` (and `.name` delegates through), so msg examples can print it. A non-empty name stays truthy, so existing callers are safe.

Diagnostics are placed where the REPL is free: right after `connect()` for the msg examples (which already break/reset) and scripts that talk to the REPL immediately, and after the guard `send_break_signal()` for scripts that stop a running app first. `ota_flash.py` is intentionally left without the extra REPL round-trips (it already prints the device name and must not risk hanging before a flash).

**3. Error handling, docstrings, README** (`143de95`)
- The `brilliant_ble` examples caught every exception and printed a misleading "Not connected to Device" even for unrelated errors, and called `disconnect()` at the end of the `try` body so a mid-script error leaked the connection. Moved `disconnect()` into `finally:` and report the actual error, matching the `brilliant_msg` examples.
- Added a one-line module docstring to each `brilliant_ble` example that had none.
- Updated the `brilliant_ble` README quickstart to the same `finally`-based cleanup and to show the device name now returned by `connect()`.

**4. `test_ble` path fix** (`9dbe054`)
`test_upload_from_file` uploaded `"./lua/test.lua"`, a path relative to the cwd. Run from the workspace root (as `uv`/pytest do) the file doesn't exist, so `upload_file()` raised `FileNotFoundError` before the test reached `disconnect()` — leaving the Halo connected. A connected device stops advertising, so the next test failed at `connect()` with "No matching device found", and the leaked connection persisted across full-suite runs. Anchored the path to the test file's own directory via `__file__`. Both tests now pass in isolation and in the full suite (6 passed) with a Halo in range.

## Scope

In scope: `brilliant_ble/examples/*` (18), `brilliant_msg/examples/*` (29), and the `brilliant_ble/tests/*` manual hardware scripts (~22).

Left untouched (no hardware connection to standardize): the pytest unit tests (`brilliant_msg/tests/*`, `brilliant_ble/tests/test_ble.py`, `test_chunk_lua_string.py`, `test_smp.py`) and the non-connecting `tx_sound_effect.py` message-type module. The PEP 723 inline-dependency header used by the firmware standalone scripts is not added, since these run inside the uv workspace.

## Verification
- All changed scripts byte-compile; `--help` works end-to-end via `uv run` for representative files in each group.
- Hardware-free unit suite green: `152 passed` (`brilliant_msg/tests`, `test_smp`, etc.).
- `test_ble.py`: `6 passed` with a Halo in range (was 2 failing before the path fix).
- The 2 pre-existing `test_ble` failures were confirmed unrelated to the standardization work (reproduced with the library change stashed) and are resolved by commit 4.
