### PR TITLE
Drain stray print banner in connect() across all SDKs

### DIFF
--- a/flutter/packages/brilliant_ble/lib/brilliant_device.dart
+++ b/flutter/packages/brilliant_ble/lib/brilliant_device.dart
@@ -1,4 +1,5 @@
 
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
@@ -139,6 +140,45 @@ class BrilliantDevice {
       else {
         rethrow;
       }
+    }
+  }
+
+  /// Discards any unsolicited print output currently arriving on the channel
+  /// (e.g. the 'interrupted'/reboot banner produced by a break or reset), so
+  /// the next `sendString(awaitResponse: true)` receives a clean response
+  /// rather than the stray banner.
+  ///
+  /// Bounded so it never hangs: returns after [quiet] of silence, or [maxTotal]
+  /// at the latest. An idle device emits nothing, so the common case costs a
+  /// single quiet window. A break only prints 'interrupted' when it actually
+  /// interrupts a running chunk, and the banner can span more than one
+  /// notification, so we soak up everything until the channel goes quiet rather
+  /// than awaiting a single line.
+  Future<void> drainPrintChannel({
+    Duration quiet = const Duration(milliseconds: 250),
+    Duration maxTotal = const Duration(milliseconds: 1500),
+  }) async {
+    if (rxChannel == null) return;
+    final done = Completer<void>();
+    Timer? quietTimer;
+    void restartQuiet() {
+      quietTimer?.cancel();
+      quietTimer = Timer(quiet, () {
+        if (!done.isCompleted) done.complete();
+      });
+    }
+
+    final sub = stringResponse.listen((_) => restartQuiet());
+    restartQuiet(); // start the silence clock even if nothing ever arrives
+    final cap = Timer(maxTotal, () {
+      if (!done.isCompleted) done.complete();
+    });
+    try {
+      await done.future;
+    } finally {
+      quietTimer?.cancel();
+      cap.cancel();
+      await sub.cancel();
     }
   }
 

--- a/flutter/packages/simple_brilliant_app/lib/simple_brilliant_app.dart
+++ b/flutter/packages/simple_brilliant_app/lib/simple_brilliant_app.dart
@@ -129,7 +129,12 @@ mixin SimpleFrameAppState<T extends StatefulWidget> on State<T> {
         // TODO looks like if the signal comes too early after connection, it isn't registered
         await Future.delayed(const Duration(milliseconds: 500));
         await frame!.sendBreakSignal();
-        await Future.delayed(const Duration(milliseconds: 500));
+
+        // Soak up any 'interrupted'/reboot banner the break produced (e.g. from
+        // an auto-running main.lua) so the first awaited sendString below gets a
+        // clean response instead of the stray banner. Bounded, and a no-op (one
+        // short quiet window) on an idle device.
+        await frame!.drainPrintChannel();
 
         await frame!.sendString(
             'print("Connected to " .. frame.HARDWARE_VERSION .. " " .. frame.FIRMWARE_VERSION .. ", Mem: " .. tostring(collectgarbage("count")))',

--- a/python/packages/brilliant_ble/src/brilliant_ble/brilliant_ble.py
+++ b/python/packages/brilliant_ble/src/brilliant_ble/brilliant_ble.py
@@ -320,6 +320,30 @@ class BrilliantBle:
         # stream audio as write-without-response (response=False)
         await self._client.write_gatt_char(self._audio_tx_characteristic, data, response=await_bt_response)
 
+    async def drain_print_channel(self, quiet=0.25, max_total=1.5):
+        """
+        Discards any unsolicited print output currently arriving on the channel
+        (e.g. the 'interrupted'/reboot banner produced by a break or reset), so
+        the next `send_lua(await_print=True)` receives a clean response rather
+        than the stray banner.
+
+        Bounded so it never hangs: returns after `quiet` seconds of silence, or
+        `max_total` seconds at the latest. An idle device emits nothing, so the
+        common case costs a single `quiet` window. A break only prints
+        'interrupted' when it actually interrupts a running chunk, and the
+        banner can span more than one notification, so we soak up everything
+        until the channel goes quiet rather than awaiting a single line.
+        """
+        loop = asyncio.get_running_loop()
+        start = loop.time()
+        while loop.time() - start < max_total:
+            self._awaiting_print_response = True
+            try:
+                await asyncio.wait_for(self._print_response.get(), timeout=quiet)
+            except asyncio.TimeoutError:
+                break
+        self._awaiting_print_response = False
+
     async def send_reset_signal(self, show_me=False):
         """
         Sends a reset signal to the device which will reset the Lua virtual

--- a/python/packages/brilliant_msg/src/brilliant_msg/brilliant_msg.py
+++ b/python/packages/brilliant_msg/src/brilliant_msg/brilliant_msg.py
@@ -46,6 +46,12 @@ class BrilliantMsg:
                 # Another break signal in case of auto-starting main.lua
                 await self.ble.send_break_signal()
 
+                # Soak up any 'interrupted'/reboot banner the break/reset/break
+                # sequence produced, so the caller's first
+                # send_lua(await_print=True) gets a clean channel. Bounded, and
+                # a no-op (one short quiet window) on an idle device.
+                await self.ble.drain_print_channel()
+
             return device_name
 
         except Exception as e:

--- a/webbluetooth/packages/brilliant-ble/src/brilliant-ble.ts
+++ b/webbluetooth/packages/brilliant-ble/src/brilliant-ble.ts
@@ -544,6 +544,46 @@ export class BrilliantBle {
     }
 
     /**
+     * Discards any unsolicited print output currently arriving on the channel
+     * (e.g. the 'interrupted'/reboot banner produced by a break or reset), so
+     * the next `sendLua({ awaitPrint: true })` receives a clean response rather
+     * than the stray banner.
+     *
+     * Bounded so it never hangs: returns after `quietMs` of silence, or
+     * `maxTotalMs` at the latest. An idle device emits nothing, so the common
+     * case costs a single quiet window. A break only prints 'interrupted' when
+     * it actually interrupts a running chunk, and the banner can span more than
+     * one notification, so we soak up everything until the channel goes quiet
+     * rather than awaiting a single line.
+     * @param quietMs Silence (ms) that marks the channel drained. Defaults to 250.
+     * @param maxTotalMs Hard cap (ms) so it always returns. Defaults to 1500.
+     */
+    public async drainPrintChannel(quietMs = 250, maxTotalMs = 1500): Promise<void> {
+        const start = Date.now();
+        while (Date.now() - start < maxTotalMs) {
+            const gotOne = await new Promise<boolean>((resolve) => {
+                if (this.printTimeoutId) clearTimeout(this.printTimeoutId);
+                this.awaitingPrintResponse = true;
+                this.printResolve = () => resolve(true);
+                this.printTimeoutId = setTimeout(() => {
+                    if (this.awaitingPrintResponse) {
+                        this.awaitingPrintResponse = false;
+                        this.printResolve = undefined;
+                        resolve(false);
+                    }
+                }, quietMs);
+            });
+            if (this.printTimeoutId) {
+                clearTimeout(this.printTimeoutId);
+                this.printTimeoutId = undefined;
+            }
+            if (!gotOne) break; // quiet window elapsed with no print
+        }
+        this.awaitingPrintResponse = false;
+        this.printResolve = undefined;
+    }
+
+    /**
      * Sends a reset signal (0x04) to the Frame device.
      * This typically causes the device to restart its Lua environment.
      * @param showMe If true, logs the transmitted signal (hex format) to the console. Defaults to false.

--- a/webbluetooth/packages/brilliant-msg/src/brilliant-msg.ts
+++ b/webbluetooth/packages/brilliant-msg/src/brilliant-msg.ts
@@ -115,6 +115,12 @@ export class BrilliantMsg {
                 await this.ble.sendBreakSignal();
                 await this.ble.sendResetSignal();
                 await this.ble.sendBreakSignal();
+
+                // Soak up any 'interrupted'/reboot banner the break/reset/break
+                // sequence produced, so the caller's first
+                // sendLua({ awaitPrint: true }) gets a clean channel. Bounded,
+                // and a no-op (one short quiet window) on an idle device.
+                await this.ble.drainPrintChannel();
             }
             return connectionResult;
         } catch (e) {


### PR DESCRIPTION
## What

A break/reset during `connect()` can leave an `interrupted`/reboot banner on the print channel, which the caller's **first** `send_lua(await_print=True)` (or `sendLua({awaitPrint:true})` / `sendString(awaitResponse:true)`) would wrongly return instead of its own result. This adds a bounded `drainPrintChannel()` to each SDK's BLE layer, called at the end of the connect init sequence, so the first read after connect is always clean.

## Why this shape (empirical, Halo EC)

- A break only prints `interrupted` when it **actually interrupts a running chunk**. An idle break/reset emit **nothing** (and on this firmware `0x04` reset emits no reboot banner at all).
- So "just `await_print` after the break" would **hang** on the common idle connect — the drain can't await a single line.
- The banner can span **more than one notification** (`…: interrupted` + a separate `\n`), so the drain soaks until the channel goes quiet rather than grabbing one line.
- Bounded by a quiet window (250ms) and a hard cap (1500ms): never hangs, and is a no-op single quiet window on an idle device (idle connect measured ~2.6s total, dominated by BLE scan/connect).

## Changes

| SDK | Drain | Wired into |
|---|---|---|
| python | `BrilliantBle.drain_print_channel()` | `BrilliantMsg.connect()` |
| webbluetooth | `BrilliantBle.drainPrintChannel()` | `BrilliantMsg.connect()` |
| flutter | `BrilliantDevice.drainPrintChannel()` | `SimpleFrameApp.connectToScannedFrame()` |

No version bumps / no publish.

## Testing

- **Python:** hardware-validated on Halo — reproduced the bug (first read `'interrupted'`) without the drain, confirmed clean (`'SENTINEL42'`) with it; 160 `brilliant_msg` tests pass.
- **WebBluetooth:** ran the `brilliant-msg` example in Chrome against a Halo — connected, printed version/memory cleanly, no `interrupted`.
- **Flutter:** ran an example on iPhone against a Halo — connected cleanly, no `interrupted`.

## Follow-up (not in this PR)

The two Python examples (`imu_heading.py`, `imu_calibrate.py`) still carry a local `drain_prints` workaround, but those files live on the `fix/halo-imu-magnetometer-axes` branch (not `main`). Removing them is a small cleanup for that branch once it rebases onto this change — harmless redundancy until then.