### PR TITLE
Fix emulator crash in examples by removing sandbox_dir

### DIFF
--- a/python/packages/halo_emulator/examples/paired_plain_text.py
+++ b/python/packages/halo_emulator/examples/paired_plain_text.py
@@ -42,7 +42,7 @@ async def main() -> None:
     # ---- connection ----
     if args.emulator:
         from halo_emulator import HaloEmulator, EmulatorBrilliantMsg
-        emu = HaloEmulator(sandbox_dir="./lua")
+        emu = HaloEmulator()
         frame = EmulatorBrilliantMsg(emu)
     else:
         from brilliant_msg import BrilliantMsg          # type: ignore[import]

--- a/python/packages/halo_emulator/examples/paired_tap_counter.py
+++ b/python/packages/halo_emulator/examples/paired_tap_counter.py
@@ -27,7 +27,7 @@ async def main() -> None:
     # ---- connection ----
     if args.emulator:
         from halo_emulator import HaloEmulator, EmulatorBrilliantMsg
-        emu = HaloEmulator(sandbox_dir="./lua")
+        emu = HaloEmulator()
         frame = EmulatorBrilliantMsg(emu)
     else:
         from brilliant_msg import BrilliantMsg          # type: ignore[import]


### PR DESCRIPTION
I noticed that running `paired_tap_counter.py` and `paired_plain_text.py` with the `--emulator` flag crashes immediately with a `SameFileError`/`PermissionError`. 

This happens because `sandbox_dir` was mapped to `./lua`, causing the emulator to try and copy the source files over themselves during the `upload_frame_app` call. 

Removing the `sandbox_dir` argument allows the emulator to use a standard temporary directory instead. This perfectly fixes the crash and keeps the source directory clean by preventing library files from being downloaded into the source tree. Let me know if this looks good to you!
