### PR TITLE
Fix Halo camera flash rendering as a random stripe (hold white frame 40ms)

### DIFF
--- a/python/packages/brilliant_msg/examples/lua/camera_frame_app.lua
+++ b/python/packages/brilliant_msg/examples/lua/camera_frame_app.lua
@@ -21,6 +21,10 @@ function show_flash()
 		frame.sleep(0.04)
 	else
 		frame.display.clear(0xFFFFFF)
+		-- Halo draws straight into the live framebuffer (no vsync/present), so
+		-- hold the white frame for at least one full ~16ms panel scan or the
+		-- flash tears into a partial stripe. 40ms matches the Frame branch.
+		frame.sleep(0.04)
 		frame.display.clear(0x000000)
 	end
 end

--- a/webbluetooth/packages/brilliant-msg/example/lua/audio_video_stream_frame_app.lua
+++ b/webbluetooth/packages/brilliant-msg/example/lua/audio_video_stream_frame_app.lua
@@ -25,6 +25,10 @@ function show_flash()
 		frame.sleep(0.04)
 	else
 		frame.display.clear(0xFFFFFF)
+		-- Halo draws straight into the live framebuffer (no vsync/present), so
+		-- hold the white frame for at least one full ~16ms panel scan or the
+		-- flash tears into a partial stripe. 40ms matches the Frame branch.
+		frame.sleep(0.04)
 		frame.display.clear(0x000000)
 	end
 end

--- a/webbluetooth/packages/brilliant-msg/example/lua/auto_exposure_frame_app.lua
+++ b/webbluetooth/packages/brilliant-msg/example/lua/auto_exposure_frame_app.lua
@@ -25,6 +25,10 @@ function show_flash()
 		frame.sleep(0.04)
 	else
 		frame.display.clear(0xFFFFFF)
+		-- Halo draws straight into the live framebuffer (no vsync/present), so
+		-- hold the white frame for at least one full ~16ms panel scan or the
+		-- flash tears into a partial stripe. 40ms matches the Frame branch.
+		frame.sleep(0.04)
 		frame.display.clear(0x000000)
 	end
 end

--- a/webbluetooth/packages/brilliant-msg/example/lua/camera_frame_app.lua
+++ b/webbluetooth/packages/brilliant-msg/example/lua/camera_frame_app.lua
@@ -21,6 +21,10 @@ function show_flash()
 		frame.sleep(0.04)
 	else
 		frame.display.clear(0xFFFFFF)
+		-- Halo draws straight into the live framebuffer (no vsync/present), so
+		-- hold the white frame for at least one full ~16ms panel scan or the
+		-- flash tears into a partial stripe. 40ms matches the Frame branch.
+		frame.sleep(0.04)
 		frame.display.clear(0x000000)
 	end
 end

--- a/webbluetooth/packages/brilliant-msg/example/lua/camera_sprite_frame_app.lua
+++ b/webbluetooth/packages/brilliant-msg/example/lua/camera_sprite_frame_app.lua
@@ -23,6 +23,10 @@ function show_flash()
 		frame.sleep(0.04)
 	else
 		frame.display.clear(0xFFFFFF)
+		-- Halo draws straight into the live framebuffer (no vsync/present), so
+		-- hold the white frame for at least one full ~16ms panel scan or the
+		-- flash tears into a partial stripe. 40ms matches the Frame branch.
+		frame.sleep(0.04)
 		frame.display.clear(0x000000)
 	end
 end

--- a/webbluetooth/packages/brilliant-msg/example/lua/live_camera_feed_frame_app.lua
+++ b/webbluetooth/packages/brilliant-msg/example/lua/live_camera_feed_frame_app.lua
@@ -21,6 +21,10 @@ function show_flash()
 		frame.sleep(0.04)
 	else
 		frame.display.clear(0xFFFFFF)
+		-- Halo draws straight into the live framebuffer (no vsync/present), so
+		-- hold the white frame for at least one full ~16ms panel scan or the
+		-- flash tears into a partial stripe. 40ms matches the Frame branch.
+		frame.sleep(0.04)
 		frame.display.clear(0x000000)
 	end
 end

--- a/webbluetooth/packages/brilliant-msg/example/lua/manual_exposure_frame_app.lua
+++ b/webbluetooth/packages/brilliant-msg/example/lua/manual_exposure_frame_app.lua
@@ -23,6 +23,10 @@ function show_flash()
 		frame.sleep(0.04)
 	else
 		frame.display.clear(0xFFFFFF)
+		-- Halo draws straight into the live framebuffer (no vsync/present), so
+		-- hold the white frame for at least one full ~16ms panel scan or the
+		-- flash tears into a partial stripe. 40ms matches the Frame branch.
+		frame.sleep(0.04)
 		frame.display.clear(0x000000)
 	end
 end


### PR DESCRIPTION
## Summary

On Halo, `show_flash()` in the camera frame apps cleared the display to white and immediately back to black:

```lua
frame.display.clear(0xFFFFFF)
frame.display.clear(0x000000)
```

The white framebuffer only lived ~3 ms (confirmed via firmware `lua_display` debug logs), against a ~16 ms panel scan period. Halo's display path draws straight into the live framebuffer with no vsync/present, so the scanout caught the white frame for only part of the screen — a sporadic white band at a scan-phase-dependent position (vertical on the rotated panel), right before each capture. This artifact had been repeatedly mistaken for a firmware display-memory corruption bug.

The Frame branch of the same function always held its flash for 40 ms. This PR gives the Halo branch the same hold, so the flash renders as the intended full-screen blink:

```lua
frame.display.clear(0xFFFFFF)
-- Halo draws straight into the live framebuffer (no vsync/present), so
-- hold the white frame for at least one full ~16ms panel scan or the
-- flash tears into a partial stripe. 40ms matches the Frame branch.
frame.sleep(0.04)
frame.display.clear(0x000000)
```

Applied to all 7 affected Lua frame apps (1 python, 6 webbluetooth). The Flutter apps have no Halo flash (`-- TODO`) and are unaffected.

## Diagnosis notes

- Reproduced on Halo EC with `live_camera_feed.py`: 10–20 visible stripes in a 45 s run, one white `clear` pair logged per capture cycle.
- Ruled out firmware causes: CDC200 FIFO-underrun/bus-error counters (temporary diagnostic build) stayed at zero during the repro; a static test pattern survived heavy capture/readout/reset soak tests without framebuffer corruption.
- General property demonstrated without the camera: instant white→black clears paint stripes at varying positions; a tight red/blue clear loop shows rolling tear bands; ≥0.5 s per color alternation is clean. Any whole-screen draw that changes again within a scan period will tear — SDK apps should hold full-screen states for at least one frame time.

## Testing

- Ran patched `live_camera_feed.py` against Halo EC (fw 0.8.7-debug): stripes gone, deliberate full-screen flash before each capture.
