### PR TITLE
Show a full-frame flash on camera capture on Halo

### DIFF
--- a/python/packages/brilliant_msg/examples/lua/camera_frame_app.lua
+++ b/python/packages/brilliant_msg/examples/lua/camera_frame_app.lua
@@ -20,7 +20,13 @@ function show_flash()
 		frame.display.show()
 		frame.sleep(0.04)
 	else
+		-- Halo draws straight into the live framebuffer (no vsync/present):
+		-- wake the panel from power_save, then hold the white frame for
+		-- several ~16ms scan periods before blanking, or the flash tears into
+		-- a partial stripe (or, with the panel still asleep, never shows).
+		frame.display.power_save(false)
 		frame.display.clear(0xFFFFFF)
+		frame.sleep(0.04)
 		frame.display.clear(0x000000)
 	end
 end

--- a/webbluetooth/packages/brilliant-msg/example/lua/audio_video_stream_frame_app.lua
+++ b/webbluetooth/packages/brilliant-msg/example/lua/audio_video_stream_frame_app.lua
@@ -24,7 +24,13 @@ function show_flash()
 		frame.display.show()
 		frame.sleep(0.04)
 	else
+		-- Halo draws straight into the live framebuffer (no vsync/present):
+		-- wake the panel from power_save, then hold the white frame for
+		-- several ~16ms scan periods before blanking, or the flash tears into
+		-- a partial stripe (or, with the panel still asleep, never shows).
+		frame.display.power_save(false)
 		frame.display.clear(0xFFFFFF)
+		frame.sleep(0.04)
 		frame.display.clear(0x000000)
 	end
 end

--- a/webbluetooth/packages/brilliant-msg/example/lua/auto_exposure_frame_app.lua
+++ b/webbluetooth/packages/brilliant-msg/example/lua/auto_exposure_frame_app.lua
@@ -24,7 +24,13 @@ function show_flash()
 		frame.display.show()
 		frame.sleep(0.04)
 	else
+		-- Halo draws straight into the live framebuffer (no vsync/present):
+		-- wake the panel from power_save, then hold the white frame for
+		-- several ~16ms scan periods before blanking, or the flash tears into
+		-- a partial stripe (or, with the panel still asleep, never shows).
+		frame.display.power_save(false)
 		frame.display.clear(0xFFFFFF)
+		frame.sleep(0.04)
 		frame.display.clear(0x000000)
 	end
 end

--- a/webbluetooth/packages/brilliant-msg/example/lua/camera_frame_app.lua
+++ b/webbluetooth/packages/brilliant-msg/example/lua/camera_frame_app.lua
@@ -20,7 +20,13 @@ function show_flash()
 		frame.display.show()
 		frame.sleep(0.04)
 	else
+		-- Halo draws straight into the live framebuffer (no vsync/present):
+		-- wake the panel from power_save, then hold the white frame for
+		-- several ~16ms scan periods before blanking, or the flash tears into
+		-- a partial stripe (or, with the panel still asleep, never shows).
+		frame.display.power_save(false)
 		frame.display.clear(0xFFFFFF)
+		frame.sleep(0.04)
 		frame.display.clear(0x000000)
 	end
 end

--- a/webbluetooth/packages/brilliant-msg/example/lua/camera_sprite_frame_app.lua
+++ b/webbluetooth/packages/brilliant-msg/example/lua/camera_sprite_frame_app.lua
@@ -22,7 +22,13 @@ function show_flash()
 		frame.display.show()
 		frame.sleep(0.04)
 	else
+		-- Halo draws straight into the live framebuffer (no vsync/present):
+		-- wake the panel from power_save, then hold the white frame for
+		-- several ~16ms scan periods before blanking, or the flash tears into
+		-- a partial stripe (or, with the panel still asleep, never shows).
+		frame.display.power_save(false)
 		frame.display.clear(0xFFFFFF)
+		frame.sleep(0.04)
 		frame.display.clear(0x000000)
 	end
 end

--- a/webbluetooth/packages/brilliant-msg/example/lua/live_camera_feed_frame_app.lua
+++ b/webbluetooth/packages/brilliant-msg/example/lua/live_camera_feed_frame_app.lua
@@ -20,7 +20,13 @@ function show_flash()
 		frame.display.show()
 		frame.sleep(0.04)
 	else
+		-- Halo draws straight into the live framebuffer (no vsync/present):
+		-- wake the panel from power_save, then hold the white frame for
+		-- several ~16ms scan periods before blanking, or the flash tears into
+		-- a partial stripe (or, with the panel still asleep, never shows).
+		frame.display.power_save(false)
 		frame.display.clear(0xFFFFFF)
+		frame.sleep(0.04)
 		frame.display.clear(0x000000)
 	end
 end

--- a/webbluetooth/packages/brilliant-msg/example/lua/manual_exposure_frame_app.lua
+++ b/webbluetooth/packages/brilliant-msg/example/lua/manual_exposure_frame_app.lua
@@ -22,7 +22,13 @@ function show_flash()
 		frame.display.show()
 		frame.sleep(0.04)
 	else
+		-- Halo draws straight into the live framebuffer (no vsync/present):
+		-- wake the panel from power_save, then hold the white frame for
+		-- several ~16ms scan periods before blanking, or the flash tears into
+		-- a partial stripe (or, with the panel still asleep, never shows).
+		frame.display.power_save(false)
 		frame.display.clear(0xFFFFFF)
+		frame.sleep(0.04)
 		frame.display.clear(0x000000)
 	end
 end


### PR DESCRIPTION
## Summary

The camera frame apps signal each capture with a brief white "flash" on the display. On Halo, this update was faster than a panel scan period and could run while the display was still in power-save, so the flash rendered inconsistently — sometimes as a partial band, sometimes not at all.

This change makes the Halo flash render as a consistent full-screen cue:

```lua
-- Halo draws straight into the live framebuffer (no vsync/present):
-- wake the panel from power_save, then hold the white frame for
-- several ~16ms scan periods before blanking, or the flash tears into
-- a partial stripe (or, with the panel still asleep, never shows).
frame.display.power_save(false)
frame.display.clear(0xFFFFFF)
frame.sleep(0.04)
frame.display.clear(0x000000)
```

The 40 ms hold matches the Frame branch of the same function, which has always held its flash for 40 ms.

Applied to all 7 camera frame apps across the python and webbluetooth SDKs. The Flutter apps don't implement a Halo flash yet and are unchanged.

## General note for example authors

Halo's display is immediate-mode — draws land in the live framebuffer as they execute. Whole-screen states that should be *seen* need to persist for at least one full scan period (~16 ms); sub-frame-time flips render partially. Same applies to any flash/blink effect in app code.

## Testing

Ran `live_camera_feed.py` against a Halo dev kit: the flash renders as a visible full-screen blink before each capture.
