### PR TITLE
webbluetooth: release prep — fix dts output path, release brilliant-sdk 1.1.0

### DIFF
--- a/webbluetooth/packages/brilliant-msg/vite.config.ts
+++ b/webbluetooth/packages/brilliant-msg/vite.config.ts
@@ -11,5 +11,5 @@ export default defineConfig({
     },
     outDir: 'dist',
   },
-  plugins: [dts()],
+  plugins: [dts({ entryRoot: 'src' })],
 });

--- a/webbluetooth/packages/brilliant-sdk/CHANGELOG.md
+++ b/webbluetooth/packages/brilliant-sdk/CHANGELOG.md
@@ -1,0 +1,8 @@
+## 1.1.0
+
+* Rebundles `brilliant-msg` 2.1.0 — the Halo firmware 0.8.8 true-up. `RxTap` now emits Halo's native tap kind (`single`/`double`/`triple`) directly instead of inferring it from timing, and the `tap.lua` and `sprite.lua` device libraries are updated to match
+* `brilliant-msg` dependency floor raised to `^2.1.0`
+
+Note: `brilliant-sdk` bundles `brilliant-ble` and `brilliant-msg` into its `dist/` output, so picking up a dependency update requires a new release of this package rather than just a re-install.
+
+Releases before 1.1.0 predate this changelog; see the `brilliant-ble` and `brilliant-msg` changelogs for the corresponding history.

--- a/webbluetooth/packages/brilliant-sdk/package.json
+++ b/webbluetooth/packages/brilliant-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brilliant-sdk",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "main": "dist/brilliant-sdk.umd.js",
   "module": "dist/brilliant-sdk.es.js",
   "types": "dist/index.d.ts",
@@ -26,7 +26,7 @@
   "description": "Brilliant Labs WebBluetooth SDK — meta-package for brilliant-ble and brilliant-msg",
   "dependencies": {
     "brilliant-ble": "^1.0.0",
-    "brilliant-msg": "^2.0.0"
+    "brilliant-msg": "^2.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.15.17",


### PR DESCRIPTION
Release prep for the webbluetooth SDK, so the Halo firmware 0.8.8 true-up in `brilliant-msg` 2.1.0 actually reaches npm users. Two independent changes.

## 1. Pin the dts `entryRoot` (`brilliant-msg`)

`brilliant-msg/package.json` declares `"types": "dist/index.d.ts"`, but a fresh `npm run build` was emitting declarations to `dist/brilliant-msg/src/` instead — so that entry pointed at a file that doesn't exist, and every `dist/rx/*` / `dist/tx/*` declaration moved.

Cause: the tsconfig alias added in 156683d maps `brilliant-ble` to `../brilliant-ble/src/index.ts` for TypeDoc. That pulls a sibling package's sources into the TS program, so `vite-plugin-dts` computes a common root of `packages/` rather than `brilliant-msg/src`, and nests output one level deep.

The published 2.0.0 predates that alias, so **no released version is affected** — but the next publish off this tree would have shipped broken types to every TypeScript consumer.

Fix is one line: `dts({ entryRoot: 'src' })`, which makes the declaration layout independent of whatever the path aliases drag into the program.

Verified the rebuilt `dist/` declaration set matches published 2.0.0 exactly, plus the two genuinely new files (`mag-calibration.d.ts`, `compass-heading.d.ts`):

```
$ comm -23 <old-2.0.0-dts-list> <new-dts-list>     # missing vs 2.0.0
(empty)
$ comm -13 <old-2.0.0-dts-list> <new-dts-list>     # new in 2.1.0
compass-heading.d.ts
mag-calibration.d.ts
```

## 2. Release `brilliant-sdk` 1.1.0

`brilliant-sdk` is a vite `build.lib` with no `rollupOptions.external`, so its `dist/` statically inlines `brilliant-ble` and `brilliant-msg` (the ES bundle is ~1 MB). That makes its `^2.0.0` range on `brilliant-msg` effectively cosmetic: npm users of the meta-package stay on whatever msg code was bundled at publish time and would never pick up 2.1.0's changes — the native `RxTap` tap kinds and the updated `tap.lua` / `sprite.lua` device libraries.

So the meta-package needs its own release to carry the true-up through:

- `version` 1.0.1 → 1.1.0
- `dependencies.brilliant-msg` `^2.0.0` → `^2.1.0`, documenting the real floor
- new `CHANGELOG.md` (the package had none), which also records the bundling behaviour so the next dependency update doesn't get missed

Historical 1.0.0 / 1.0.1 entries are deliberately not backfilled — they predate the changelog.

## Publish plan once this merges

`brilliant-msg` 2.1.0 then `brilliant-sdk` 1.1.0, in that order — `brilliant-sdk/node_modules/brilliant-msg` is a workspace symlink, so msg has to be rebuilt before the sdk build inlines it.

The Python and Flutter halves of this release are already out: `brilliant-msg` 7.1.0 and `halo-emulator` 2.0.0 (first PyPI release) on PyPI, `brilliant_msg` 4.1.0 and `simple_brilliant_app` 9.1.0 on pub.dev. The Python and Flutter meta-packages resolve dependencies at install time, so they needed no republish — this bundling problem is npm-only.
