### PR TITLE
Release the ble packages and pin the consumers that need them

### DIFF
--- a/flutter/packages/brilliant_ble/CHANGELOG.md
+++ b/flutter/packages/brilliant_ble/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 5.1.0
+
+* New `BrilliantDevice.drainPrintChannel()` — discards unsolicited print output already arriving on the channel (such as the `interrupted`/reboot banner produced by a break or reset) so the next `sendString(awaitResponse: true)` receives a clean response rather than the stray banner. Bounded so it never hangs: returns after `quiet` of silence, or `maxTotal` at the latest
+* New `BrilliantBluetooth.getSystemConnectedDevices()` — returns all Brilliant devices connected at the system level. Such devices do not advertise, so scanning can never find them; on iOS an ANCS-soliciting Halo is auto-connected by the system, making this the common case rather than the exception. The existing single-device `getSystemConnectedDevice(uuid)` is unchanged
+* `scan()` now yields system-connected devices first, then falls back to scanning for advertising ones (system-connected entries have no RSSI reading)
+
+These were added to the source during the Halo firmware 0.8.8 work but shipped without a version bump. `simple_brilliant_app` 9.1.0 calls `drainPrintChannel()` while still allowing `brilliant_ble ^5.0.0`, so a fresh resolve could pick 5.0.1 and fail. Use `simple_brilliant_app` 9.1.1 or later, which requires this release.
+
 ## 5.0.1
 
 * Fixed `uploadScript` failing on Lua files containing non-ASCII characters (e.g. `°`): chunks are now sized by UTF-8 byte length rather than string length, so multi-byte characters can no longer push a packet over the MTU (#12). Multi-byte characters and escape sequences are never split across chunks

--- a/flutter/packages/brilliant_ble/pubspec.yaml
+++ b/flutter/packages/brilliant_ble/pubspec.yaml
@@ -1,6 +1,6 @@
 name: brilliant_ble
 description: 'Low level BLE communication for the Brilliant Labs Frame using Flutter Blue Plus'
-version: 5.0.1
+version: 5.1.0
 # homepage:
 repository: https://github.com/brilliantLabsAR/brilliant_sdk
 

--- a/flutter/packages/simple_brilliant_app/CHANGELOG.md
+++ b/flutter/packages/simple_brilliant_app/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 9.1.1
+
+* Raised the `brilliant_ble` constraint to `^5.1.0`. 9.1.0 calls `BrilliantDevice.drainPrintChannel()`, which only exists from `brilliant_ble` 5.1.0 — under the previous `^5.0.0` constraint a fresh resolve could pick 5.0.1 and fail. No other changes
+
 ## 9.1.0
 
 True-up against Halo firmware 0.8.8.

--- a/flutter/packages/simple_brilliant_app/pubspec.yaml
+++ b/flutter/packages/simple_brilliant_app/pubspec.yaml
@@ -1,6 +1,6 @@
 name: simple_brilliant_app
 description: "Flutter and Lua quickstart app scaffolding and standard library functions for Brilliant Labs Halo and Frame development on Android/iOS"
-version: 9.1.0
+version: 9.1.1
 homepage:
 repository: https://github.com/brilliantLabsAR/brilliant_sdk
 
@@ -15,7 +15,7 @@ dependencies:
   image: ^4.2.0
   logging: ^1.2.0
   brilliant_msg: ^4.0.0
-  brilliant_ble: ^5.0.0
+  brilliant_ble: ^5.1.0
 
 dev_dependencies:
   flutter_test:

--- a/python/packages/brilliant_ble/CHANGELOG.md
+++ b/python/packages/brilliant_ble/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.2.0
+
+* New `drain_print_channel(quiet=0.25, max_total=1.5)` — discards unsolicited print output already arriving on the channel (such as the `interrupted`/reboot banner produced by a break or reset) so the next `send_lua(await_print=True)` receives a clean response rather than the stray banner. Bounded so it never hangs: returns after `quiet` seconds of silence, or `max_total` at the latest
+* New `name` property returning the connected device's name
+
+Both were added to the source during the Halo firmware 0.8.8 work but shipped without a version bump. `brilliant-msg` 7.1.0 calls `drain_print_channel()` while still allowing `brilliant-ble >= 3.0.0`, so a fresh install could resolve 3.1.1 and fail with `AttributeError` on `connect()`. Use `brilliant-msg` 7.1.1 or later, which requires this release.
+
 ## 3.1.1
 
 * Fixed `upload_file_from_string()` failing on Lua files containing non-ASCII characters (e.g. `°`): chunks are now sized by UTF-8 byte length rather than string length, so multi-byte characters can no longer push a packet over the MTU. Multi-byte characters and escape sequences are never split across chunks

--- a/python/packages/brilliant_ble/pyproject.toml
+++ b/python/packages/brilliant_ble/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "brilliant-ble"
-version = "3.1.1"
+version = "3.2.0"
 dependencies = [
     "bleak >= 0.22.3, < 1.0.0",
 ]

--- a/python/packages/brilliant_msg/CHANGELOG.md
+++ b/python/packages/brilliant_msg/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.1.1
+
+* Raised the `brilliant-ble` floor to `>=3.2.0`. 7.1.0's `connect()` calls `BrilliantBle.drain_print_channel()`, which only exists from `brilliant-ble` 3.2.0 — under the previous `>=3.0.0` floor a fresh install could resolve 3.1.1 and fail with `AttributeError` on connect. No other changes
+
 ## 7.1.0
 
 True-up against Halo firmware 0.8.8.

--- a/python/packages/brilliant_msg/pyproject.toml
+++ b/python/packages/brilliant_msg/pyproject.toml
@@ -4,12 +4,12 @@ build-backend = "hatchling.build"
 
 [project]
 name = "brilliant-msg"
-version = "7.1.0"
+version = "7.1.1"
 dependencies = [
     "lz4>=4.4.3,<5.0.0",
     "numpy>=2.2.3,<3.0.0",
     "pillow>=11.1.0,<12.0.0",
-    "brilliant-ble>=3.0.0"
+    "brilliant-ble>=3.2.0"
 ]
 authors = [
     { name = "luke-brilliant" },

--- a/webbluetooth/packages/brilliant-ble/CHANGELOG.md
+++ b/webbluetooth/packages/brilliant-ble/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.1.0
+
+* New `drainPrintChannel(quietMs = 250, maxTotalMs = 1500)` — discards unsolicited print output already arriving on the channel (such as the `interrupted`/reboot banner produced by a break or reset) so the next awaited response is clean rather than the stray banner. Bounded so it never hangs: resolves after `quietMs` of silence, or `maxTotalMs` at the latest
+
+Added to the source during the Halo firmware 0.8.8 work but shipped without a version bump. `brilliant-msg` bundles `brilliant-ble` into its own output, so no released `brilliant-msg` was affected; this release brings the standalone package back in step with the source.
+
 ## 1.0.1
 
 * Fixed `uploadFileFromString()` failing on Lua files containing non-ASCII characters (e.g. `°`): chunks are now sized by UTF-8 byte length rather than string length, so multi-byte characters can no longer push a packet over the MTU. Multi-byte characters and escape sequences are never split across chunks

--- a/webbluetooth/packages/brilliant-ble/package.json
+++ b/webbluetooth/packages/brilliant-ble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brilliant-ble",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "main": "dist/brilliant-ble.umd.js",
   "module": "dist/brilliant-ble.es.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Fixes two broken releases and the root cause behind them. Found while smoke-testing today's publishes from a clean venv against a Halo EC dev kit — the very first `connect()` blew up.

## Root cause

a3c6d17 ("Drain stray print banner in connect() across all SDKs", #30) added new public API to all three `ble` packages **without bumping any of their versions**:

| Package | Added |
|---|---|
| `brilliant-ble` (Python) | `drain_print_channel()`, `name` property |
| `brilliant_ble` (Flutter) | `drainPrintChannel()`, `getSystemConnectedDevices()`, system-connected devices yielded from `scan()` |
| `brilliant-ble` (npm) | `drainPrintChannel()` |

The consuming packages were then bumped and published, so the registries ended up holding consumers that call methods their published dependency does not define.

This is invisible in-repo: the uv workspace and the pubspec path overrides both resolve `ble` from source, so every local test passes. It only appears on a clean install from a registry.

## Confirmed broken

- **`brilliant-msg` 7.1.0 (PyPI)** calls `ble.drain_print_channel()` but allows `brilliant-ble >= 3.0.0`. 3.1.1 is the newest published and doesn't define it:
  ```
  File ".../brilliant_msg/brilliant_msg.py", line 53, in connect
      await self.ble.drain_print_channel()
  AttributeError: 'BrilliantBle' object has no attribute 'drain_print_channel'
  ```
- **`simple_brilliant_app` 9.1.0 (pub.dev)** calls `frame!.drainPrintChannel()` but allows `brilliant_ble ^5.0.0`, which resolves to 5.0.1 without it.

`brilliant-msg` 7.0.0 and `simple_brilliant_app` 9.0.1 did **not** call these methods, so the breakage is new as of today's releases.

**npm is unaffected** — `brilliant-msg` inlines `brilliant-ble` source into its own bundle (via the tsconfig `paths` alias), so the implementation ships with it regardless of the declared range.

## This PR

Minor bumps for the three `ble` packages — everything is additive, nothing removed. In particular the single-device `getSystemConnectedDevice(uuid)` is still present alongside the new plural `getSystemConnectedDevices()`, so Flutter is 5.1.0 rather than a major.

| Package | From | To |
|---|---|---|
| `brilliant-ble` (PyPI) | 3.1.1 | **3.2.0** |
| `brilliant-msg` (PyPI) | 7.1.0 | **7.1.1** — floor raised to `>=3.2.0` |
| `brilliant_ble` (pub.dev) | 5.0.1 | **5.1.0** |
| `simple_brilliant_app` (pub.dev) | 9.1.0 | **9.1.1** — constraint raised to `^5.1.0` |
| `brilliant-ble` (npm) | 1.0.1 | **1.1.0** — brings the standalone package back in step with source |

The broken versions are superseded rather than yanked: once 7.1.1 and 9.1.1 exist, resolvers prefer them and nothing new lands on the broken combination.

## Worth considering separately

The reason this got through is that no CI or local check ever resolves these packages the way a user does. A publish-time check that installs each package from a scratch environment against its *declared* ranges — rather than the workspace — would have caught it before the first upload.
