### PR TITLE
webbluetooth: fix TS 5.9 type error breaking the docs deploy

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -150,7 +150,43 @@ up in the tarball. Stash unrelated changes first.
 - Python `__version__` is derived from installed package metadata, so it needs no
   manual update — never reintroduce a hardcoded version string.
 
-## 8. After publishing
+## 8. Build the reference docs before publishing
+
+Each ecosystem publishes API docs through a different pipeline, and **all three fail
+after the fact** — a docs break is invisible until the merge or the upload has already
+happened. Build all of them locally first.
+
+```bash
+# npm -> GitHub Pages (workflow runs typedoc on push to main)
+cd webbluetooth/packages/brilliant-ble && npm run docs:api
+cd ../brilliant-msg && npm run docs:api
+
+# Python -> Read the Docs (builds on push to main)
+cd python
+uv run --extra docs --package brilliant-ble \
+  sphinx-build -b html packages/brilliant_ble/docs/source /tmp/sx-ble
+uv run --extra docs --package brilliant-msg \
+  sphinx-build -b html packages/brilliant_msg/docs/source /tmp/sx-msg
+
+# Dart -> pub.dev (generates dartdoc only AFTER the version is published)
+cd flutter/packages/<pkg> && dart doc --output /tmp/dartdoc-<pkg>
+```
+
+The Dart one matters most: `flutter pub publish --dry-run` does **not** run dartdoc,
+and pub.dev only generates docs once the version is live — which cannot be unpublished.
+
+Known-harmless noise: sphinx warns `html_static_path entry '_static' does not exist`,
+and dartdoc reports a few unresolved-reference warnings. Neither fails the build, so
+do not add `-W` without fixing those first.
+
+Only `brilliant_ble` and `brilliant_msg` have Read the Docs configs; `brilliant-sdk`
+and `halo-emulator` have none, so their docs are the README on PyPI.
+
+Sphinx `release` and Python `__version__` both derive from installed package
+metadata. Never reintroduce a hardcoded version in `docs/source/conf.py` — it silently
+mislabels the published docs.
+
+## 9. After publishing
 
 Verify from a scratch project outside the repo — a fresh install of each published
 package, plus an import and a real call. If hardware is available, connect to a

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -96,6 +96,11 @@ bundle. Consequences:
   TypeScript, update typedoc in the same change or `npm install` fails with
   `ERESOLVE`; if the declared typedoc range already allows a newer release,
   `npm update typedoc` is enough and no manifest edit is needed.
+- **`vite build` is not a type check.** Its dts step reports type errors without
+  failing the build, so a broken type can pass `npm run build` cleanly and still
+  break the docs workflow, which runs `typedoc` and exits non-zero. Run
+  `npm run docs:api` in `brilliant-ble` and `brilliant-msg` before publishing, or
+  the GitHub Pages deploy fails after the merge.
 - Declaration output is pinned with `dts({ entryRoot: 'src' })`. Without it, a
   `paths` alias that pulls a sibling's sources into the program shifts declarations
   into a nested directory and silently breaks the declared `types` entry. If

--- a/python/packages/brilliant_ble/docs/source/conf.py
+++ b/python/packages/brilliant_ble/docs/source/conf.py
@@ -12,7 +12,14 @@ sys.path.insert(0, os.path.abspath('../../src'))
 project = 'brilliant_ble'
 copyright = '2025, luke-brilliant'
 author = 'luke-brilliant'
-release = '3.0.0'
+# Derived from the installed package metadata so it cannot drift from
+# pyproject.toml the way a hardcoded string does.
+from importlib.metadata import PackageNotFoundError, version as _pkg_version
+
+try:
+    release = _pkg_version("brilliant-ble")
+except PackageNotFoundError:  # building without an install
+    release = "0.0.0.dev0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/python/packages/brilliant_msg/docs/source/conf.py
+++ b/python/packages/brilliant_msg/docs/source/conf.py
@@ -12,7 +12,14 @@ sys.path.insert(0, os.path.abspath('../../src'))
 project = 'brilliant_msg'
 copyright = '2025, luke-brilliant'
 author = 'luke-brilliant'
-release = '7.0.0'
+# Derived from the installed package metadata so it cannot drift from
+# pyproject.toml the way a hardcoded string does.
+from importlib.metadata import PackageNotFoundError, version as _pkg_version
+
+try:
+    release = _pkg_version("brilliant-msg")
+except PackageNotFoundError:  # building without an install
+    release = "0.0.0.dev0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -107,7 +107,7 @@ wheels = [
 
 [[package]]
 name = "brilliant-ble"
-version = "3.1.1"
+version = "3.2.0"
 source = { editable = "packages/brilliant_ble" }
 dependencies = [
     { name = "bleak" },
@@ -142,7 +142,7 @@ provides-extras = ["examples", "tests", "docs"]
 
 [[package]]
 name = "brilliant-msg"
-version = "7.1.0"
+version = "7.1.1"
 source = { editable = "packages/brilliant_msg" }
 dependencies = [
     { name = "brilliant-ble" },

--- a/webbluetooth/packages/brilliant-msg/src/rx/photo.ts
+++ b/webbluetooth/packages/brilliant-msg/src/rx/photo.ts
@@ -237,7 +237,11 @@ export class RxPhoto {
 
         // Put the original image data into the temporary canvas
         tempCtx.putImageData(new ImageData(
-            new Uint8ClampedArray(rawImageData.data.buffer),
+            // The buffer is typed ArrayBufferLike, but ImageData requires a view
+            // backed by a plain ArrayBuffer. TypeScript 5.9 enforces that
+            // distinction; the canvas ImageData this comes from is never
+            // SharedArrayBuffer-backed, so assert rather than copy.
+            new Uint8ClampedArray(rawImageData.data.buffer as ArrayBuffer),
             rawImageData.width,
             rawImageData.height
         ), 0, 0);


### PR DESCRIPTION
**The Deploy WebBluetooth Docs workflow has been failing on every push to `main` since #38.** It is still failing now — #39 did not fix it, it just moved the failure later.

## What happened

#38 pinned `typescript` to `5.9.3`, which surfaced a latent variance error in `brilliant-msg`:

```
src/rx/photo.ts:240 - error TS2769: No overload matches this call.
  Argument of type 'Uint8ClampedArray<ArrayBufferLike>' is not assignable to parameter of type 'ImageDataArray'.
    Type 'SharedArrayBuffer' is missing the following properties from type 'ArrayBuffer': resizable, resize, ...
```

`rawImageData.data.buffer` is typed `ArrayBufferLike`, but `ImageData` requires a view backed by a plain `ArrayBuffer` — a distinction TS 5.9 now enforces.

The two failures look identical from the outside but are different:

| Run | Failure | Duration |
|---|---|---|
| after #38 | `ERESOLVE` during install (typedoc peer conflict) | 18s |
| after #39 | `typedoc` type error — install now succeeds | 29s |

So #39 was correct and necessary; it let the workflow get past install and reach the real problem.

## Why local verification missed it

**`vite build` is not a type check.** Its dts step reports type errors without failing the build. On the same tree:

```
npm run build     → 0 errors reported, exit 0
npm run docs:api  → Found 1 errors,    exit 3   ← what the workflow runs
```

I verified builds and tests before publishing but never ran `docs:api`, so this was invisible until the post-merge workflow.

## The fix

One site — `brilliant-ble` is clean, and it's the only such construct in either package. The canvas `ImageData` it comes from is never `SharedArrayBuffer`-backed, so assert the buffer type rather than copying it.

**Type-only: the emitted JavaScript is unchanged, so the published `brilliant-msg` 3.0.0 needs no republish.** Only the docs workflow was broken.

Also records in the release skill that `npm run build` is not a type check, and that `docs:api` must be run before publishing.

## Verification

On this branch: `docs:api` passes, `npm run build` reports 0 errors, and all 12 `brilliant-msg` tests pass. The workflow will re-run automatically on merge to `main`, which is the real confirmation.
