### PR TITLE
Examples/tests cleanup: guard frame.log, apply the --name convention

### DIFF
--- a/python/packages/brilliant_ble/examples/halo_fetch_logs.py
+++ b/python/packages/brilliant_ble/examples/halo_fetch_logs.py
@@ -1,0 +1,76 @@
+"""Fetch the persisted /lfs log files from a Halo via the frame.log Lua API,
+then restart main.lua so the device returns to its normal app.
+
+frame.log is only compiled into firmware builds with logging support, so
+released firmware usually does not have it. This example checks for it and
+exits cleanly when it is missing.
+"""
+import asyncio
+import argparse
+
+from brilliant_ble import BrilliantBle
+
+# how many characters of a log file to pull back per print()
+CHUNK = 180
+
+
+async def main():
+    parser = argparse.ArgumentParser(
+        description="Fetch the persisted firmware log files from a Halo over BLE.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
+    halo = BrilliantBle()
+
+    try:
+        name = await halo.connect(name=args.name)
+        print(f"# connected to {name}", flush=True)
+
+        # stop the running app so we have the Lua prompt to ourselves
+        await halo.send_break_signal()
+        await asyncio.sleep(0.3)
+
+        has_log = await halo.send_lua("print(frame.log ~= nil)",
+                                      await_print=True, timeout=10)
+        if has_log.strip() != "true":
+            print("# this device does not support frame.log - nothing to fetch",
+                  flush=True)
+            return
+
+        files = await halo.send_lua(
+            'local t={} for _,f in ipairs(frame.log.list()) do '
+            't[#t+1]=f.name..":"..f.size end print(table.concat(t,","))',
+            await_print=True, timeout=10)
+        print(f"# log files: {files}", flush=True)
+
+        for entry in [e.strip() for e in files.split(",") if e.strip()]:
+            log_name = entry.split()[0].split(":")[0]
+            print(f"\n===== {entry} =====", flush=True)
+            # Load file into a global, then stream it out in chunks.
+            await halo.send_lua(f'__l = frame.log.read("{log_name}") print(#__l)',
+                                await_print=True, timeout=15)
+            size = int(await halo.send_lua("print(#__l)",
+                                           await_print=True, timeout=10))
+            i = 1
+            while i <= size:
+                chunk = await halo.send_lua(
+                    f"print(string.sub(__l,{i},{i + CHUNK - 1}))",
+                    await_print=True, timeout=10)
+                print(chunk, end="", flush=True)
+                i += CHUNK
+            await halo.send_lua("__l = nil print(1)", await_print=True, timeout=10)
+
+    except Exception as e:
+        print(f"An error occurred: {e}")
+    finally:
+        if halo.is_connected():
+            print("\n# restarting main.lua", flush=True)
+            await halo.send_reset_signal()
+        await halo.disconnect()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/python/packages/brilliant_ble/examples/halo_standby.py
+++ b/python/packages/brilliant_ble/examples/halo_standby.py
@@ -1,0 +1,46 @@
+"""Put a Halo into standby (low-power sleep), then disconnect.
+
+Standby is a Halo-only feature; the device wakes on AAD, tap, Bluetooth or
+the button.
+"""
+import asyncio
+import argparse
+
+from brilliant_ble import BrilliantBle, BrilliantDeviceType
+
+
+async def main():
+    parser = argparse.ArgumentParser(
+        description="Connect to a Halo device over BLE and put it into standby.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
+    frame = BrilliantBle()
+
+    try:
+        await frame.connect(name=args.name)
+
+        # stop any application, if running, so we can send lua commands
+        await frame.send_break_signal()
+
+        if frame._type != BrilliantDeviceType.HALO:
+            print("standby() is a Halo-only feature")
+            return
+
+        await frame.send_lua("frame.standby()", await_print=False)
+        print("Halo put into Standby mode (wakes on AAD, tap, bluetooth, button)")
+
+        # Give Halo time to run the standby() in the Lua REPL before disconnecting
+        await asyncio.sleep(1)
+
+    except Exception as e:
+        print(f"An error occurred: {e}")
+    finally:
+        await frame.disconnect()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/python/packages/brilliant_ble/tests/test_camera.py
+++ b/python/packages/brilliant_ble/tests/test_camera.py
@@ -1,7 +1,9 @@
 from aioconsole import ainput
-from brilliant_ble import BrilliantBle
+import argparse
 import asyncio
 import time
+
+from brilliant_ble import BrilliantBle
 
 image_buffer = b""
 image_suffix = 1
@@ -24,6 +26,13 @@ def receive_data(data):
 
 
 async def main():
+    parser = argparse.ArgumentParser(description="Connect to a Halo/Frame device over BLE and run this test.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help='exact BLE device name, e.g. "Halo AB" or "Frame 4F"; defaults to the nearest device',
+    )
+    args = parser.parse_args()
 
     lua_script = """
 
@@ -62,6 +71,7 @@ async def main():
     # Connect to bluetooth and upload file
     b = BrilliantBle()
     await b.connect(
+        name=args.name,
         print_response_handler=lambda s: print(s),
         data_response_handler=receive_data,
     )
@@ -81,5 +91,4 @@ async def main():
     await b.disconnect()
 
 
-loop = asyncio.new_event_loop()
-loop.run_until_complete(main())
+asyncio.run(main())

--- a/python/packages/brilliant_msg/examples/lua/wake_on_audio_frame_app.lua
+++ b/python/packages/brilliant_msg/examples/lua/wake_on_audio_frame_app.lua
@@ -18,9 +18,12 @@ function app_loop()
 
 	-- tell the host program that the frameside app is ready (waiting on await_print)
 	print('Frame app is running')
-	--print(frame.time.utc() .. ' Clearing firmware logs on Halo')
-	--frame.log.clear()
-	--frame.sleep(0.5) -- not sure if the clear is finishing cleanly
+	-- frame.log is only present in firmware built with logging support
+	--if frame.log ~= nil then
+	--	print(frame.time.utc() .. ' Clearing firmware logs on Halo')
+	--	frame.log.clear()
+	--	frame.sleep(0.5) -- not sure if the clear is finishing cleanly
+	--end
 
 
 	print(frame.time.utc() .. ' Standby, then streaming audio on wake from AAD, tap, Bluetooth')
@@ -70,13 +73,18 @@ function app_loop()
 			print(frame.time.utc() .. ' Stopping audio stream after 3 seconds')
 			frame.microphone.stop()
 
-			-- dump the firmware logs back to the host
-			print(frame.time.utc() .. ' Dumping firmware logs to host')
-			frame.log.list()
-			print(frame.time.utc() .. ' Log file #0')
-			frame.log.show(0)
-			print(frame.time.utc() .. ' Log file #1')
-			frame.log.show(1)
+			-- dump the firmware logs back to the host, if this firmware
+			-- build has logging support compiled in
+			if frame.log == nil then
+				print(frame.time.utc() .. ' Skipping firmware log dump: this device does not support frame.log')
+			else
+				print(frame.time.utc() .. ' Dumping firmware logs to host')
+				frame.log.list()
+				print(frame.time.utc() .. ' Log file #0')
+				frame.log.show(0)
+				print(frame.time.utc() .. ' Log file #1')
+				frame.log.show(1)
+			end
 		end
 		--frame.yield()
 	end


### PR DESCRIPTION
Cleanup pass over the Python examples and hardware tests.

## Guard `frame.log` usage

`frame.log` is conditionally compiled into the firmware, so released firmware
on user devices usually does not have it. Examples that call it now check
first instead of erroring out.

- `wake_on_audio_frame_app.lua`: the log dump is wrapped in
  `if frame.log == nil`, matching the `frame.sound == nil` idiom already in
  `sound_effects_frame_app.lua`. The commented-out `frame.log.clear()` block
  gained the same guard inside the comment, so uncommenting it stays safe.
- `halo_fetch_logs.py` (new): probes `frame.log ~= nil` and exits cleanly when
  logging is not built in.

These were the only two `frame.log` users in the SDK — nothing in the Flutter
or TypeScript packages touches it.

## Apply the `--name` convention to the last two stragglers

Every other example and hardware test takes an optional `--name` and falls back
to the nearest device. A survey of all 72 files that open a device connection
found exactly two that hardcoded a bare `connect()`:

- `tests/test_camera.py`: added `--name`; also switched to `asyncio.run(main())`
  like its 17 siblings instead of building an event loop by hand.
- `examples/halo_standby.py` (new): takes `--name`, and no longer claims the
  device was put into standby when it skipped the Halo-only call on a Frame.

`tests/test_ble.py` is deliberately left alone — it is the one genuinely
automated file in there (`unittest.IsolatedAsyncioTestCase`), so argparse would
fight the test runner over `sys.argv`, and its bare `connect()` /
`connect(name="NOT_A_REAL_DEVICE")` / `connect(name=device_name)` calls are
each asserting something specific.

## Testing

Both new/changed Python files pass `py_compile`; the modified Lua compiles
under the emulator's Lua 5.4 runtime. The behavioural paths need hardware and
have not been run on a device.

No package versions bumped — examples and tests only, nothing to publish.
