### PR TITLE
deps: allow Pillow 12 for brilliant-msg

### DIFF
--- a/python/packages/brilliant_msg/pyproject.toml
+++ b/python/packages/brilliant_msg/pyproject.toml
@@ -8,7 +8,7 @@ version = "7.1.1"
 dependencies = [
     "lz4>=4.4.3,<5.0.0",
     "numpy>=2.2.3,<3.0.0",
-    "pillow>=11.1.0,<12.0.0",
+    "pillow>=11.1.0,<13.0.0",
     "brilliant-ble>=3.2.0"
 ]
 authors = [

--- a/python/packages/brilliant_msg/tests/test_pillow_compatibility.py
+++ b/python/packages/brilliant_msg/tests/test_pillow_compatibility.py
@@ -1,17 +1,34 @@
 """Packaging compatibility checks for the published brilliant-msg metadata."""
 
-from importlib import metadata
+from pathlib import Path
+import tomllib
 
 from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
 from packaging.version import Version
 
 
-def test_published_metadata_allows_pillow_12():
-    """The published dependency requirement must admit the Pillow 12 line."""
-    pillow_requirement = next(
-        Requirement(requirement)
-        for requirement in metadata.requires("brilliant-msg") or []
-        if Requirement(requirement).name.lower() == "pillow"
-    )
+def test_source_metadata_has_single_pillow_compatibility_envelope():
+    """The checked-in manifest must declare the complete supported Pillow range."""
+    manifest_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    with manifest_path.open("rb") as manifest:
+        project = tomllib.load(manifest)["project"]
 
-    assert Version("12.0.0") in pillow_requirement.specifier
+    requirements = [Requirement(raw) for raw in project.get("dependencies", [])]
+    pillow_requirements = [
+        requirement
+        for requirement in requirements
+        if canonicalize_name(requirement.name) == "pillow"
+    ]
+
+    assert len(pillow_requirements) == 1, (
+        "expected exactly one Pillow dependency, found "
+        f"{len(pillow_requirements)}"
+    )
+    pillow_specifier = pillow_requirements[0].specifier
+
+    for version in ("11.1.0", "12.0.0", "12.1.0", "12.999.0"):
+        assert Version(version) in pillow_specifier
+
+    assert Version("11.0.9") not in pillow_specifier
+    assert Version("13.0.0") not in pillow_specifier

--- a/python/packages/brilliant_msg/tests/test_pillow_compatibility.py
+++ b/python/packages/brilliant_msg/tests/test_pillow_compatibility.py
@@ -1,11 +1,44 @@
 """Packaging compatibility checks for the published brilliant-msg metadata."""
 
 from pathlib import Path
-import tomllib
+import sys
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 from packaging.requirements import Requirement
 from packaging.utils import canonicalize_name
 from packaging.version import Version
+
+
+def test_python_310_toml_backport_is_declared_in_dev_group():
+    """The Python 3.10 fallback must be supplied by the dev dependency group."""
+    workspace_manifest_path = Path(__file__).resolve().parents[3] / "pyproject.toml"
+    with workspace_manifest_path.open("rb") as manifest:
+        workspace = tomllib.load(manifest)
+
+    dev_requirements = [
+        Requirement(raw)
+        for raw in workspace.get("dependency-groups", {}).get("dev", [])
+    ]
+    tomli_requirements = [
+        requirement
+        for requirement in dev_requirements
+        if canonicalize_name(requirement.name) == "tomli"
+    ]
+
+    assert len(tomli_requirements) == 1, (
+        "expected exactly one Python 3.10 TOML backport dependency, found "
+        f"{len(tomli_requirements)}"
+    )
+    tomli_requirement = tomli_requirements[0]
+
+    assert str(tomli_requirement.marker) == 'python_version < "3.11"'
+    assert {str(specifier) for specifier in tomli_requirement.specifier} == {
+        ">=2.0.1"
+    }
 
 
 def test_source_metadata_has_single_pillow_compatibility_envelope():

--- a/python/packages/brilliant_msg/tests/test_pillow_compatibility.py
+++ b/python/packages/brilliant_msg/tests/test_pillow_compatibility.py
@@ -1,0 +1,17 @@
+"""Packaging compatibility checks for the published brilliant-msg metadata."""
+
+from importlib import metadata
+
+from packaging.requirements import Requirement
+from packaging.version import Version
+
+
+def test_published_metadata_allows_pillow_12():
+    """The published dependency requirement must admit the Pillow 12 line."""
+    pillow_requirement = next(
+        Requirement(requirement)
+        for requirement in metadata.requires("brilliant-msg") or []
+        if Requirement(requirement).name.lower() == "pillow"
+    )
+
+    assert Version("12.0.0") in pillow_requirement.specifier

--- a/python/packages/brilliant_msg/tests/test_pillow_compatibility.py
+++ b/python/packages/brilliant_msg/tests/test_pillow_compatibility.py
@@ -25,7 +25,16 @@ def test_source_metadata_has_single_pillow_compatibility_envelope():
         "expected exactly one Pillow dependency, found "
         f"{len(pillow_requirements)}"
     )
-    pillow_specifier = pillow_requirements[0].specifier
+    pillow_requirement = pillow_requirements[0]
+
+    assert not pillow_requirement.extras, "Pillow must not request extras"
+    assert pillow_requirement.marker is None, "Pillow must not be conditional"
+    assert {str(specifier) for specifier in pillow_requirement.specifier} == {
+        ">=11.1.0",
+        "<13.0.0",
+    }
+
+    pillow_specifier = pillow_requirement.specifier
 
     for version in ("11.1.0", "12.0.0", "12.1.0", "12.999.0"):
         assert Version(version) in pillow_specifier

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -2,6 +2,7 @@
 dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
+    "tomli>=2.0.1; python_version < '3.11'",
 ]
 
 [tool.pytest.ini_options]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -183,7 +183,7 @@ requires-dist = [
     { name = "numpy", specifier = ">=2.2.3,<3.0.0" },
     { name = "numpy", marker = "extra == 'examples'", specifier = ">=1.24" },
     { name = "opencv-python", marker = "extra == 'tests'", specifier = ">=4.0.0" },
-    { name = "pillow", specifier = ">=11.1.0,<12.0.0" },
+    { name = "pillow", specifier = ">=11.1.0,<13.0.0" },
     { name = "pvspeaker", marker = "extra == 'tests'", specifier = ">=1.0.0" },
     { name = "pytest", marker = "extra == 'tests'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'tests'", specifier = ">=0.23" },

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -22,6 +22,7 @@ members = [
 dev = [
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=0.23" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.1" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Allow `brilliant-msg` to declare compatibility with Pillow 12 while retaining its Pillow 11.1 floor and a Pillow 13 ceiling.
- Guard the published source requirement directly so future lockfile or installed-metadata differences cannot hide an accidental compatibility regression.

## Related Issues and Pull Requests

Relates to LetsGetToWorkBro/dreamlayer#655

## Changes

- Widen the direct `brilliant-msg` Pillow requirement to `>=11.1.0,<13.0.0`.
- Add source-manifest tests for the exact unconditional Pillow range, including boundary and representative Pillow 12 membership checks.
- Add a Python 3.10-compatible `tomli` fallback for the development-only manifest test.
- Update the workspace lock metadata without adding `tomli` to `brilliant-msg` runtime dependencies.

## Testing

- `python/.venv/bin/pytest -q python/packages/brilliant_msg/tests/test_pillow_compatibility.py` — 2 passed on Python 3.12.
- `(cd python && uv lock --check)` — passed.
- Fork CI on Python 3.10 ran the focused compatibility tests — 2 passed.
- Fork CI confirmed all 24 mirrored Lua files remain identical across the three SDKs.
- Focused mutation checks rejected a restored Pillow 12 ceiling, interior exclusions, a missing Pillow 13 ceiling, conditional markers, dependency extras, and both Python 3.10 fallback regressions.

## Follow-ups / Known Limitations

The workspace still resolves Pillow 11.3.0 because `halo-emulator` independently retains `<12.0.0`; this change only widens the published `brilliant-msg` envelope.

## Dependencies

`tomli>=2.0.1` is added only to the workspace development group for Python versions below 3.11. It is not a `brilliant-msg` runtime dependency.

Generated by GPT-5.6 Luna (implementation), GPT-5.6 Sol (brief, review, testing, verification)
