### PR TITLE
test(file_api): make the root-listing deltas idempotent

### DIFF
--- a/python/packages/brilliant_ble/tests/test_file_api.py
+++ b/python/packages/brilliant_ble/tests/test_file_api.py
@@ -180,6 +180,16 @@ async def main():
     test = TestBluetooth()
     await test.initialize(args.name)
 
+    # Clear anything a previous interrupted run of THIS test may have left in
+    # the root: a leftover test.lua/test2.lua or the /this tree would be
+    # counted into `base` below, and since the steps that follow overwrite
+    # rather than re-create them, the +1/-1 delta assertions would then be off
+    # by one. remove() of an absent path is a no-op here (the _probe pcall
+    # swallows it), so this is safe on a clean device.
+    for leftover in ("test.lua", "test2.lua",
+                     "/this/is/some/path", "/this/is/some", "/this/is", "/this"):
+        await test._probe(f"frame.file.remove('{leftover}')")
+
     # Entry count before this test adds anything. Asserting on deltas rather
     # than on absolute counts keeps the test valid on a device that already
     # holds recordings from the microphone or AEC harnesses.


### PR DESCRIPTION
## Summary

`test_file_api.py` measures a `base = #listdir('/')` and asserts `base + 1`
after creating a file and `base` again after removing it. Those deltas assume
the paths it creates (`test.lua`, `test2.lua`, and the `/this` tree) don't
already exist. If a previous run was interrupted before its own cleanup, a
leftover `test.lua` is counted into `base`; the `open('test.lua', 'w')` that
follows overwrites it instead of adding an entry, so every `+1`/`-1` assertion
is then off by one — reporting 37/41 with four `#listdir('/') => N != N+1`
failures.

## Change

Remove the paths this test owns before measuring `base`. `frame.file.remove`
of an absent path is swallowed by the `_probe` pcall, so this is a no-op on a
clean device.

## Verified

On a dev kit: with a `test.lua` planted in `/` beforehand, the current test
reproduces the four failures and this change passes 41/41.

Found while validating the firmware-side RX write fix
(brilliantlabsAR/halo-firmware#7).
