### PR TITLE
halo_emulator 2.1.0: true up frame.speaker validation to firmware 0.8.9

### DIFF
--- a/python/packages/halo_emulator/CHANGELOG.md
+++ b/python/packages/halo_emulator/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 2.1.0
+
+True-up against Halo firmware 0.8.9 (`frame.FIRMWARE_VERSION` now reports
+`"0.8.9-emulator"`).
+
+### Changed
+
+* `frame.speaker` is no longer a pure no-op: `start()` validates its config
+  as firmware 0.8.9 does — sample rate 8000/16000, channels 1/2, bit depth
+  16 only, LC3 duration 750/1000 and bitrate a multiple of 8000 up to 96000,
+  volume 0-100, and the per-stream `gain` (0-12) and `budget` (10-100)
+  loudness fields added in 0.8.9. `play()` errors when the speaker is not
+  started, `volume(v)` errors when not started or out of range (it clamped
+  before), and `stop()` stays a no-op when already stopped. Still no audio
+  output
+
 ## 2.0.1
 
 ### Fixed

--- a/python/packages/halo_emulator/README.md
+++ b/python/packages/halo_emulator/README.md
@@ -242,7 +242,7 @@ the entry script from the top on wake (check `frame.wakeup_source()` there);
 `sleep()` with no argument deep-sleeps and stops the emulator.
 `frame.on_wakeup()` was removed in firmware 0.8.8 and is not provided.
 
-Constants: `HARDWARE_VERSION` (`"EMULATOR"`), `FIRMWARE_VERSION` (`"0.8.8-emulator"`), `GIT_TAG`, `SE_REVISION`
+Constants: `HARDWARE_VERSION` (`"EMULATOR"`), `FIRMWARE_VERSION` (`"0.8.9-emulator"`), `GIT_TAG`, `SE_REVISION`
 
 ### Time — `frame.time.*`
 `utc`, `zone`, `date`
@@ -307,8 +307,10 @@ sfxr presets (`pickup`, `laser`, `explosion`, `powerup`, `hit`, `jump`, `blip`)
 and options (`sample_rate`, `duration_ms`, `volume`, `seed`) are validated and
 timed exactly as on firmware, but no audio is synthesized.
 
-### Speaker — `frame.speaker.*` *(no-op)*
-`start`, `play`, `volume`, `stop` — accepted but produce no audio output.
+### Speaker — `frame.speaker.*` *(no audio output)*
+`start`, `play`, `volume`, `stop` — config and stream state are validated as
+on firmware 0.8.9, including the per-stream `gain` (0-12) and `budget`
+(10-100) loudness fields, but no audio is produced.
 
 ### Microphone — `frame.microphone.*` *(no audio capture)*
 `start`, `read`, `gain`, `stop`, `status`, `aec`, `voice`, `diag`, `aad_callback` —

--- a/python/packages/halo_emulator/pyproject.toml
+++ b/python/packages/halo_emulator/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "halo-emulator"
-version = "2.0.1"
+version = "2.1.0"
 requires-python = ">=3.10"
 dependencies = [
     "lupa>=2.0,<3.0",

--- a/python/packages/halo_emulator/src/halo_emulator/lua_runtime.py
+++ b/python/packages/halo_emulator/src/halo_emulator/lua_runtime.py
@@ -56,7 +56,7 @@ def build_lua_runtime(
     # ---- constants ----
     frame.HARDWARE_VERSION = "EMULATOR"
     # Firmware version whose behavior this emulator mirrors
-    frame.FIRMWARE_VERSION = "0.8.8-emulator"
+    frame.FIRMWARE_VERSION = "0.8.9-emulator"
     frame.GIT_TAG = "emulator"
     frame.SE_REVISION = "0.0.0"
 
@@ -130,7 +130,7 @@ def build_lua_runtime(
     comp_tbl.decompress = compression.decompress
     frame.compression = comp_tbl
 
-    # ---- speaker (no-op) ----
+    # ---- speaker (no audio output) ----
     spk_tbl = rt.table()
     spk_tbl.start = speaker.start
     spk_tbl.play = speaker.play

--- a/python/packages/halo_emulator/src/halo_emulator/stubs/speaker.py
+++ b/python/packages/halo_emulator/src/halo_emulator/stubs/speaker.py
@@ -1,4 +1,9 @@
-"""frame.speaker.* stubs — no-op for initial release."""
+"""frame.speaker.* stubs — no audio output, firmware-faithful validation.
+
+Mirrors firmware 0.8.9 lua_speaker.c: start() config validation including
+the per-stream `gain` and `budget` loudness fields added in 0.8.9, volume()
+getter/setter semantics, play() stream-state checks. No audio is produced.
+"""
 from __future__ import annotations
 
 from typing import Any
@@ -7,18 +12,76 @@ from typing import Any
 class SpeakerStub:
     def __init__(self) -> None:
         self._volume: int = 50
+        self._streaming: bool = False
 
     def start(self, cfg: Any = None) -> None:
-        pass
+        # start() while streaming is a legal stop-and-reconfigure on firmware
+        if cfg is None:
+            raise ValueError("Expected a configuration table")
 
-    def play(self, data: Any) -> None:
-        pass
+        def opt(name: str, default: Any) -> Any:
+            try:
+                val = getattr(cfg, name)
+            except AttributeError:
+                return default
+            return default if val is None else val
+
+        # Firmware treats any encoder other than "lc3" as pcm — no validation
+        use_lc3 = str(opt("encoder", "pcm")) == "lc3"
+
+        sample_rate = int(opt("sample_rate", 8000))
+        if sample_rate not in (8000, 16000):
+            raise ValueError("Sample rate must be 8000 or 16000")
+
+        channels = int(opt("channels", 1))
+        if channels not in (1, 2):
+            raise ValueError("Channels must be 1 or 2")
+
+        bit_depth = int(opt("bit_depth", 16))
+        if bit_depth != 16:
+            raise ValueError("Bit depth must be 16")
+
+        if use_lc3:
+            duration = int(opt("duration", 1000))
+            if duration not in (750, 1000):
+                raise ValueError("LC3 duration must be 750 or 1000")
+            bitrate = int(opt("bitrate", 16000))
+            if bitrate % 8000 != 0 or bitrate > 96000:
+                raise ValueError("Bitrate must be multiple of 8000 and <= 96000")
+
+        volume = int(opt("volume", 50))
+        if not 0 <= volume <= 100:
+            raise ValueError("Volume must be 0-100")
+
+        gain = int(opt("gain", 0))
+        if not 0 <= gain <= 12:
+            raise ValueError("Gain must be 0-12 dB")
+
+        budget = int(opt("budget", 0))
+        if budget != 0 and not 10 <= budget <= 100:
+            raise ValueError("Budget must be 10-100")
+
+        self._volume = volume
+        self._streaming = True
+
+    def play(self, data: Any = None) -> None:
+        if not isinstance(data, (str, bytes)):
+            raise ValueError("Expected audio data as a string")
+        if not self._streaming:
+            raise ValueError("Speaker not started")
+        # empty data returns cleanly on firmware; audio itself is not emulated
 
     def volume(self, val: int | None = None) -> int | None:
         if val is None:
             return self._volume
-        self._volume = max(0, min(100, int(val)))
+        if not self._streaming:
+            raise ValueError("Speaker not initialized")
+        val = int(val)
+        if not 0 <= val <= 100:
+            raise ValueError("Volume must be 0-100")
+        self._volume = val
         return None
 
     def stop(self) -> None:
-        pass
+        # no-op when already stopped, as on firmware
+        self._streaming = False

--- a/python/packages/halo_emulator/tests/test_firmware_parity.py
+++ b/python/packages/halo_emulator/tests/test_firmware_parity.py
@@ -1,4 +1,4 @@
-"""Firmware 0.8.8 parity tests: palette, fonts, require, time, tap, sound, mic."""
+"""Firmware 0.8.9 parity tests: palette, fonts, require, time, tap, sound, mic, speaker."""
 from __future__ import annotations
 
 import time
@@ -285,6 +285,57 @@ def test_sound_api(emulator):
         emulator.execute_lua("frame.sound.play('blip', {sample_rate=44100})")
 
 
+# ---------------------------------------------------------------- speaker
+
+def test_speaker_start_validation(emulator):
+    emulator.connect()
+    emulator.execute_lua(
+        "frame.speaker.start{encoder='lc3', sample_rate=16000, duration=1000, "
+        "channels=1, bitrate=32000, volume=50}"
+    )
+    # 0.8.9 per-stream loudness fields; start() while streaming reconfigures
+    emulator.execute_lua("frame.speaker.start{gain=12, budget=100}")
+    # any encoder other than 'lc3' falls back to pcm, as on firmware
+    emulator.execute_lua("frame.speaker.start{encoder='mp3'}")
+    with pytest.raises(Exception):
+        emulator.execute_lua("frame.speaker.start()")
+    with pytest.raises(Exception):
+        emulator.execute_lua("frame.speaker.start{sample_rate=44100}")
+    with pytest.raises(Exception):
+        emulator.execute_lua("frame.speaker.start{channels=3}")
+    with pytest.raises(Exception):
+        emulator.execute_lua("frame.speaker.start{bit_depth=8}")
+    with pytest.raises(Exception):
+        emulator.execute_lua("frame.speaker.start{encoder='lc3', duration=500}")
+    with pytest.raises(Exception):
+        emulator.execute_lua("frame.speaker.start{encoder='lc3', bitrate=100000}")
+    with pytest.raises(Exception):
+        emulator.execute_lua("frame.speaker.start{volume=101}")
+    with pytest.raises(Exception):
+        emulator.execute_lua("frame.speaker.start{gain=13}")
+    with pytest.raises(Exception):
+        emulator.execute_lua("frame.speaker.start{budget=5}")
+
+
+def test_speaker_play_and_volume_semantics(emulator):
+    emulator.connect()
+    with pytest.raises(Exception):
+        emulator.execute_lua("frame.speaker.play('\\x00\\x01')")
+    with pytest.raises(Exception):
+        emulator.execute_lua("frame.speaker.volume(80)")
+    emulator.execute_lua("frame.speaker.start{volume=30}")
+    assert emulator.execute_lua("return frame.speaker.volume()") == 30
+    emulator.execute_lua("frame.speaker.play('')")
+    emulator.execute_lua("frame.speaker.volume(80)")
+    assert emulator.execute_lua("return frame.speaker.volume()") == 80
+    with pytest.raises(Exception):
+        emulator.execute_lua("frame.speaker.volume(101)")
+    emulator.execute_lua("frame.speaker.stop()")
+    emulator.execute_lua("frame.speaker.stop()")  # no-op when already stopped
+    with pytest.raises(Exception):
+        emulator.execute_lua("frame.speaker.play('\\x00')")
+
+
 # ---------------------------------------------------------------- microphone
 
 def test_microphone_read_semantics(emulator):
@@ -337,4 +388,4 @@ def test_empty_send_transmits_nothing(emulator):
 
 def test_firmware_version_marker(emulator):
     emulator.connect()
-    assert emulator.execute_lua("return frame.FIRMWARE_VERSION") == "0.8.8-emulator"
+    assert emulator.execute_lua("return frame.FIRMWARE_VERSION") == "0.8.9-emulator"

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -407,7 +407,7 @@ wheels = [
 
 [[package]]
 name = "halo-emulator"
-version = "2.0.1"
+version = "2.1.0"
 source = { editable = "packages/halo_emulator" }
 dependencies = [
     { name = "lupa" },


### PR DESCRIPTION
## Summary

The emulator's `frame.speaker` was a pure no-op: any config passed, so a script validated in the emulator could still throw on the glasses. This trues the speaker stub up to firmware 0.8.9 `lua_speaker.c`:

- `start()` validates its config table with the firmware's checks and messages: sample rate 8000/16000, channels 1/2, bit depth 16 only, LC3 duration 750/1000 and bitrate a multiple of 8000 up to 96000, volume 0-100, and the per-stream `gain` (0-12) / `budget` (10-100) loudness fields added in 0.8.9. Any encoder other than `lc3` falls back to pcm as on firmware (which does not validate the encoder string).
- `play()` errors with "Speaker not started" when not streaming; empty data returns cleanly.
- `volume(v)` errors when the speaker is not initialized or out of 0-100 (it silently clamped before); the getter always works.
- `stop()` stays a no-op when already stopped; `start()` while streaming is a reconfigure.

`frame.FIRMWARE_VERSION` now reports `0.8.9-emulator`: the speaker fields were the only Lua-visible surface change in 0.8.9 (the battery filter and BLE ATT-offset hardening sit below the emulated layer). halo_emulator bumped to 2.1.0, changelog updated.

Audio output is still not emulated.

## Test plan

Two new tests in `test_firmware_parity.py` next to the microphone validation tests. Both fail against the previous stub (`DID NOT RAISE`) and pass with this change. Full suite: 241 passed, 6 device-skipped. `tools/check_lua_parity.py` clean (no device Lua touched).
